### PR TITLE
Exclude .keep file from .gitignore

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -4,7 +4,7 @@ keep_file "app/assets/builds"
 append_to_file "app/assets/config/manifest.js", %(//= link_tree ../builds\n)
 
 if Rails.root.join(".gitignore").exist?
-  append_to_file(".gitignore", %(/app/assets/builds\n))
+  append_to_file(".gitignore", %(/app/assets/builds\n!/app/assets/builds/.keep\n))
 end
 
 say "Remove app/assets/stylesheets/application.css so build output can take over"


### PR DESCRIPTION
Right now the whole `builds` folder is ignored so bundling on production will fail with error:
> Sprockets::ArgumentError: link_tree argument must be a directory