### PR TITLE
Ensure bin/dev is executable

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -27,3 +27,4 @@ end
 
 say "Add bin/dev to start foreman"
 copy_file "#{__dir__}/dev", "bin/dev"
+chmod "bin/dev", 0755, verbose: false


### PR DESCRIPTION
Currently `bin/dev` is not copied as an executable file. This change makes it executable.

This change mirrors the same code in https://github.com/rails/jsbundling-rails/blob/main/lib/install/install.rb