### PR TITLE
Don't enhance test:prepare unless it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ When you deploy your application to production, the `css:build` task attaches to
 
 This also happens in testing where the bundler attaches to the `test:prepare` task to ensure the stylesheets have been bundled before testing commences. (Note that this currently only applies to rails `test:*` tasks (like `test:all` or `test:controllers`), not "rails test", as that doesn't load `test:prepare`).
 
+If your test framework does not define a `test:prepare` Rake task, ensure that your test framework runs `css:build` to bundle stylesheets before testing commences.
+
 That's it!
 
 You can configure your bundler options in the `build:css` script in `package.json` or via the installer-generated `tailwind.config.js` for Tailwind or `postcss.config.js` for PostCSS.

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -6,4 +6,4 @@ namespace :css do
 end
 
 Rake::Task["assets:precompile"].enhance(["css:build"])
-Rake::Task["test:prepare"].enhance(["css:build"])
+Rake::Task["test:prepare"].enhance(["css:build"]) if Rake::Task.task_defined?("test:prepare")


### PR DESCRIPTION
Don't fail build task when test:prepare isn't defined, as described here: https://github.com/rails/jsbundling-rails/issues/10