### PR TITLE
Allow imports from node modules with default install

### DIFF
--- a/lib/install/sass/install.rb
+++ b/lib/install/sass/install.rb
@@ -3,4 +3,4 @@ copy_file "#{__dir__}/application.sass.scss", "app/assets/stylesheets/applicatio
 run "yarn add sass"
 
 say "Add build:css script"
-run %(npm set-script build:css "sass ./app/assets/stylesheets/application.sass.scss ./app/assets/builds/application.css --no-source-map")
+run %(npm set-script build:css "sass ./app/assets/stylesheets/application.sass.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules")


### PR DESCRIPTION
I ran into an issue when trialing the new gem, whereby `@import` statements wouldn't load common Sass libraries without specifying the full path to the `node_modules` directory.

This allows simple imports such as `@import 'glidecss/base';` to work with the default install.