### PR TITLE
Fallback to `db:test:prepare` when `test:prepare` rake is not found

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -6,4 +6,9 @@ namespace :css do
 end
 
 Rake::Task["assets:precompile"].enhance(["css:build"])
-Rake::Task["test:prepare"].enhance(["css:build"]) if Rake::Task.task_defined?("test:prepare")
+
+if Rake::Task.task_defined?("test:prepare")
+  Rake::Task["test:prepare"].enhance(["css:build"])
+elsif Rake::Task.task_defined?("db:test:prepare")
+  Rake::Task["db:test:prepare"].enhance(["css:build"])
+end


### PR DESCRIPTION
The rake to prepare rails test in Rails 6 (and below) is `bin/rails db:test:prepare`.