### PR TITLE
Fix gitignore pattern

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -7,7 +7,7 @@ say "Stop linking stylesheets automatically"
 gsub_file "app/assets/config/manifest.js", "//= link_directory ../stylesheets .css", ""
 
 if Rails.root.join(".gitignore").exist?
-  append_to_file(".gitignore", %(/app/assets/builds\n!/app/assets/builds/.keep\n))
+  append_to_file(".gitignore", %(/app/assets/builds/*\n!/app/assets/builds/.keep\n))
 end
 
 say "Remove app/assets/stylesheets/application.css so build output can take over"


### PR DESCRIPTION
I was deploying my app to heroku and noticed this error:

```
Sprockets::ArgumentError: link_tree argument must be a directory
```

because `app/assets/builds` not found. This should fix it.