### PR TITLE
Fix `Sprockets::ArgumentError` during deployment

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -7,7 +7,7 @@ say "Stop linking stylesheets automatically"
 gsub_file "app/assets/config/manifest.js", "//= link_directory ../stylesheets .css", ""
 
 if Rails.root.join(".gitignore").exist?
-  append_to_file(".gitignore", %(/app/assets/builds\n!/app/assets/builds/.keep\n))
+  append_to_file(".gitignore", %(/app/assets/builds/*\n!/app/assets/builds/.keep\n))
 end
 
 say "Remove app/assets/stylesheets/application.css so build output can take over"


### PR DESCRIPTION
To avoid error:

> Sprockets::ArgumentError: link_tree argument must be a directory.

This should add the pattern like this:

```
/app/assets/builds/*
!/app/assets/builds/.keep
```

The same pattern as the one in default .gitignore file generated by 
rails:

```
# Ignore all logfiles and tempfiles.
/log/*
/tmp/*
!/log/.keep
!/tmp/.keep
```