### PR TITLE
Add stylesheet link tag in application layout

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -15,11 +15,20 @@ remove_file "app/assets/stylesheets/application.css"
 
 if (app_layout_path = Rails.root.join("app/views/layouts/application.html.erb")).exist?
   say "Add stylesheet link tag in application layout"
-  insert_into_file app_layout_path.to_s,
-    %(\n    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>), before: /\s*<\/head>/
+  insert_into_file(
+    app_layout_path.to_s,
+    defined?(Turbo) ?
+      %(\n    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>) :
+      %(\n    <%= stylesheet_link_tag "application" %>),
+    before: /\s*<\/head>/
+  )
 else
   say "Default application.html.erb is missing!", :red
-  say %(        Add <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %> within the <head> tag in your custom layout.)
+  if defined?(Turbo)
+    say %(        Add <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %> within the <head> tag in your custom layout.)
+  else
+    say %(        Add <%= stylesheet_link_tag "application" %> within the <head> tag in your custom layout.)
+  end
 end
 
 unless Rails.root.join("package.json").exist?

--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -13,6 +13,15 @@ end
 say "Remove app/assets/stylesheets/application.css so build output can take over"
 remove_file "app/assets/stylesheets/application.css"
 
+if (app_layout_path = Rails.root.join("app/views/layouts/application.html.erb")).exist?
+  say "Add stylesheet link tag in application layout"
+  insert_into_file app_layout_path.to_s,
+    %(\n    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>), before: /\s*<\/head>/
+else
+  say "Default application.html.erb is missing!", :red
+  say %(        Add <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %> within the <head> tag in your custom layout.)
+end
+
 unless Rails.root.join("package.json").exist?
   say "Add default package.json"
   copy_file "#{__dir__}/package.json", "package.json"


### PR DESCRIPTION
I think this is useful for people who are migrating from `webpacker` and was using `stylesheet_pack_tag` instead of `stylesheet_link_tag`.

Similar to [jsbundling-rails](https://github.com/rails/jsbundling-rails/blob/c7f8f8564436de9529250ef6bbd511568ca6339d/lib/install/install.rb#L10).