### PR TITLE
procfile append :css on new line

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -19,7 +19,7 @@ unless Rails.root.join("package.json").exist?
 end
 
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "css: yarn build:css --watch"
+  append_to_file "Procfile.dev", "\ncss: yarn build:css --watch"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"


### PR DESCRIPTION
In an application with an existing `Procfile.dev`, the `css: yarn build:css --watch` is not appended on a new line. Adding `\n` adds the build command on a new line and avoid errors such as `| unknown command: ./bin/webpack-dev-servercss: yarn build:css --watch`