### PR TITLE
Ignore node_modules

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -7,7 +7,8 @@ say "Stop linking stylesheets automatically"
 gsub_file "app/assets/config/manifest.js", "//= link_directory ../stylesheets .css", ""
 
 if Rails.root.join(".gitignore").exist?
-  append_to_file(".gitignore", %(/app/assets/builds/*\n!/app/assets/builds/.keep\n))
+  append_to_file(".gitignore", %(\n/app/assets/builds/*\n!/app/assets/builds/.keep\n))
+  append_to_file(".gitignore", %(\n/node_modules\n))
 end
 
 say "Remove app/assets/stylesheets/application.css so build output can take over"


### PR DESCRIPTION
This will add `/node_modules` to `.gitignore` and also add a new line before `/app/assets/builds/*`.

Before:

```
...
# Ignore master key for decrypting credentials and more.
/config/master.key
/app/assets/builds/*
!/app/assets/builds/.keep
```

After:

```
...
# Ignore master key for decrypting credentials and more.
/config/master.key

/app/assets/builds/*
!/app/assets/builds/.keep

/node_modules
```

I separated the commands to make sure we don't append `/node_modules` twice.