### PR TITLE
Add bulma support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Bundling for Rails
 
-Use [Tailwind CSS](https://tailwindcss.com), [Bootstrap](https://getbootstrap.com/), [PostCSS](https://postcss.org), or [Dart Sass](https://sass-lang.com/) to bundle and process your CSS, then deliver it via the asset pipeline in Rails. This gem provides installers to get you going with the bundler of your choice in a new Rails application, and a convention to use `app/assets/builds` to hold your bundled output as artifacts that are not checked into source control (the installer adds this directory to `.gitignore` by default).
+Use [Tailwind CSS](https://tailwindcss.com), [Bootstrap](https://getbootstrap.com/), [Bulma](https://bulma.io/), [PostCSS](https://postcss.org), or [Dart Sass](https://sass-lang.com/) to bundle and process your CSS, then deliver it via the asset pipeline in Rails. This gem provides installers to get you going with the bundler of your choice in a new Rails application, and a convention to use `app/assets/builds` to hold your bundled output as artifacts that are not checked into source control (the installer adds this directory to `.gitignore` by default).
 
 You develop using this approach by running the bundler in watch mode in a terminal with `yarn build:css --watch` (and your Rails server in another, if you're not using something like [puma-dev](https://github.com/puma/puma-dev)). Whenever the bundler detects changes to any of the stylesheet files in your project, it'll bundle `app/assets/stylesheets/application.[bundler].css` into `app/assets/builds/application.css`. This build output takes over from the regular asset pipeline default file. So you continue to refer to the build output in your layout using the standard asset pipeline approach with `<%= stylesheet_link_tag "application" %>`.
 
@@ -21,9 +21,9 @@ You must already have node and yarn installed on your system. You will also need
 
 1. Add `cssbundling-rails` to your Gemfile with `gem 'cssbundling-rails'`
 2. Run `./bin/bundle install`
-3. Run `./bin/rails css:install:[tailwind|bootstrap|postcss|sass]`
+3. Run `./bin/rails css:install:[tailwind|bootstrap|bulma|postcss|sass]`
 
-Or, in Rails 7+, you can preconfigure your new application to use a specific bundler with `rails new myapp --css [tailwind|bootstrap|postcss|sass]`.
+Or, in Rails 7+, you can preconfigure your new application to use a specific bundler with `rails new myapp --css [tailwind|bootstrap|bulma|postcss|sass]`.
 
 
 ## License

--- a/lib/install/bulma/application.bulma.scss
+++ b/lib/install/bulma/application.bulma.scss
@@ -1,0 +1,39 @@
+// @charset "utf-8";
+
+// Import a Google Font
+// @import url('https://fonts.googleapis.com/css?family=Nunito:400,700');
+
+// Set your brand colors
+// $purple: #8A4D76;
+// $pink: #FA7C91;
+// $brown: #757763;
+// $beige-light: #D0D1CD;
+// $beige-lighter: #EFF0EB;
+
+// Update Bulma's global variables
+// $family-sans-serif: "Nunito", sans-serif;
+// $grey-dark: $brown;
+// $grey-light: $beige-light;
+// $primary: $purple;
+// $link: $pink;
+// $widescreen-enabled: false;
+// $fullhd-enabled: false;
+
+// Update some of Bulma's component variables
+// $body-background-color: $beige-lighter;
+// $control-border-width: 2px;
+// $input-border-color: transparent;
+// $input-shadow: none;
+
+// Import only what you need from Bulma
+// @import "bulma/sass/utilities/_all.sass";
+// @import "bulma/sass/base/_all.sass";
+// @import "bulma/sass/elements/button.sass";
+// @import "bulma/sass/elements/container.sass";
+// @import "bulma/sass/elements/title.sass";
+// @import "bulma/sass/form/_all.sass";
+// @import "bulma/sass/components/navbar.sass";
+// @import "bulma/sass/layout/hero.sass";
+// @import "bulma/sass/layout/section.sass";
+
+@import 'bulma/bulma';

--- a/lib/install/bulma/install.rb
+++ b/lib/install/bulma/install.rb
@@ -1,0 +1,7 @@
+say "Install Bulma"
+copy_file "#{__dir__}/application.bulma.scss",
+   "app/assets/stylesheets/application.bulma.scss"
+run "yarn add sass bulma"
+
+say "Add build:css script"
+run %(npm set-script build:css "sass ./app/assets/stylesheets/application.bulma.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules")

--- a/lib/tasks/cssbundling/install.rake
+++ b/lib/tasks/cssbundling/install.rake
@@ -24,5 +24,10 @@ namespace :css do
     task bootstrap: "css:install:shared" do
       system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/bootstrap/install.rb",  __dir__)}"
     end
+
+    desc "Install Bulma"
+    task bulma: "css:install:shared" do
+      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/bulma/install.rb",  __dir__)}"
+    end
   end
 end


### PR DESCRIPTION
Hi! I added Bulma CSS support to cssbundling-rails gem. I'm not sure if this is the correct way to do it, but it works on my machine, I just followed the way how bootstrap was added to it.

And [here is a clean "rails _7.0.0.alpha2_ new" repo I used to test my implementation](https://github.com/printfinn/cssbundling-bulma-test).

I don't know why `node_modules` dir is not in the `.gitignore` file by default in rails 7, so I also committed it with an additional commit to this repo (6MB dir size) in case someone needs to see it.

