### PR TITLE
Fixed Procfile.dev to remove unnecessary empty line and terminated with a newline

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -38,7 +38,7 @@ unless Rails.root.join("package.json").exist?
 end
 
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "\ncss: yarn build:css --watch"
+  append_to_file "Procfile.dev", "css: yarn build:css --watch\n"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"


### PR DESCRIPTION
Fixed contents of `Procfile.dev` generated when executing `rails new new_app -j esbuild --css tailwind`.

before(without newline terminated):

```
web: bin/rails server -p 3000
js: yarn build --watch

css: yarn build:css --watch
```

after(with newline terminated):

```
web: bin/rails server -p 3000
js: yarn build --watch
css: yarn build:css --watch
```