### PR TITLE
Expose available bundle list

### DIFF
--- a/lib/cssbundling/version.rb
+++ b/lib/cssbundling/version.rb
@@ -1,3 +1,4 @@
 module Cssbundling
   VERSION = "0.1.8"
+  BUNDLER_LIST = [:tailwind, :bootstrap, :bulma, :postcss, :sass]
 end


### PR DESCRIPTION
This PR exposes the available bundle list so Rails new helper can list them. It still requires updating the Gemfile.lock

Related to:
- https://github.com/rails/rails/issues/43251
- https://github.com/rails/rails/pull/43254

If this PR is merged and released, then we can update Rails with: https://github.com/rails/rails/pull/43255