### PR TITLE
Generated application.bulma.scss file leads to undefined variable error when commenting out customizations

### DIFF
--- a/lib/install/bulma/application.bulma.scss
+++ b/lib/install/bulma/application.bulma.scss
@@ -1,14 +1,14 @@
-// @charset "utf-8";
+@charset "utf-8";
 
 // Import a Google Font
-// @import url('https://fonts.googleapis.com/css?family=Nunito:400,700');
+// @import url("https://fonts.googleapis.com/css?family=Nunito:400,700");
 
 // Set your brand colors
-// $purple: #8A4D76;
-// $pink: #FA7C91;
+// $purple: #8a4d76;
+// $pink: #fa7c91;
 // $brown: #757763;
-// $beige-light: #D0D1CD;
-// $beige-lighter: #EFF0EB;
+// $beige-light: #d0d1cd;
+// $beige-lighter: #eff0eb;
 
 // Update Bulma's global variables
 // $family-sans-serif: "Nunito", sans-serif;
@@ -25,15 +25,23 @@
 // $input-border-color: transparent;
 // $input-shadow: none;
 
-// Import only what you need from Bulma
-// @import "bulma/sass/utilities/_all.sass";
-// @import "bulma/sass/base/_all.sass";
-// @import "bulma/sass/elements/button.sass";
-// @import "bulma/sass/elements/container.sass";
-// @import "bulma/sass/elements/title.sass";
-// @import "bulma/sass/form/_all.sass";
-// @import "bulma/sass/components/navbar.sass";
-// @import "bulma/sass/layout/hero.sass";
-// @import "bulma/sass/layout/section.sass";
+// Import only what you need from Bulma ...
+// @import "../node_modules/bulma/sass/utilities/_all.sass";
+// @import "../node_modules/bulma/sass/base/_all.sass";
+// @import "../node_modules/bulma/sass/elements/button.sass";
+// @import "../node_modules/bulma/sass/elements/container.sass";
+// @import "../node_modules/bulma/sass/elements/title.sass";
+// @import "../node_modules/bulma/sass/form/_all.sass";
+// @import "../node_modules/bulma/sass/components/navbar.sass";
+// @import "../node_modules/bulma/sass/layout/hero.sass";
+// @import "../node_modules/bulma/sass/layout/section.sass";
 
-@import 'bulma/bulma';
+// ... or import everything
+@import "bulma/sass/utilities/_all";
+@import "bulma/sass/base/_all";
+@import "bulma/sass/elements/_all";
+@import "bulma/sass/form/_all";
+@import "bulma/sass/components/_all";
+@import "bulma/sass/grid/_all";
+@import "bulma/sass/helpers/_all";
+@import "bulma/sass/layout/_all";


### PR DESCRIPTION
With the default `app/assets/stylesheets/application.bulma.scss` file generated from the `cssbundling-rails` gem, we get an error when commenting out the proposed code for customizing global variables such as `$primary`.

In particular, the `yarn css:build` process fails with:

```
Error: Undefined variable.
   ╷
91 │   @return $background
   │           ^^^^^^^^^^^
   ╵
   bulma/sass/utilities/functions.sass 91:11           findLightColor()
   bulma/sass/utilities/derived-variables.sass 26:17   @import
   bulma/sass/utilities/_all.sass 6:9                  @import
   bulma/bulma.sass 3:9                                @import
   app/assets/stylesheets/application.bulma.scss 45:9  root stylesheet
```

Instead, either import individual Bulma components (commented out), or all of it via direct imports of the `_all` files in each component directory (proposed change).

**Steps to Reproduce:**

1. Install Rails 7.0.2.alpha2 via `gem install rails --pre`
2. Generate a new application with "Bulma" option: `rails new hello-rails7 --css bulma`
3. Redefine `$primary: "#FFAADD";` in `app/assets/stylesheets/application.bulma.scss` anywhere above `@import "bulma/bulma"
4. Start dev server via `bin/dev`
5. Observe `css` process fail with above error message.
