### PR TITLE
Replace postcss-preset-env

### DIFF
--- a/lib/install/postcss/install.rb
+++ b/lib/install/postcss/install.rb
@@ -1,7 +1,7 @@
-say "Install PostCSS w/ postcss-preset-env"
+say "Install PostCSS w/ nesting and autoprefixer"
 copy_file "#{__dir__}/postcss.config.js", "postcss.config.js"
 copy_file "#{__dir__}/application.postcss.css", "app/assets/stylesheets/application.postcss.css"
-run "yarn add postcss postcss-cli postcss-preset-env"
+run "yarn add postcss postcss-cli postcss-nesting autoprefixer"
 
 say "Add build:css script"
 run %(npm set-script build:css "postcss ./app/assets/stylesheets/application.postcss.css -o ./app/assets/builds/application.css")

--- a/lib/install/postcss/postcss.config.js
+++ b/lib/install/postcss/postcss.config.js
@@ -1,10 +1,6 @@
 module.exports = {
   plugins: [
-    require('postcss-preset-env')({ 
-      stage: 2,
-      features: {
-        'nesting-rules': true
-      }
-    })
+    require('postcss-nesting'),
+    require('autoprefixer'),
   ],
 }


### PR DESCRIPTION
This replaces `postcss-preset-env` with `postcss-nesting` and `autoprefixer` to resolve a dependency issue and improve build speed.

Closes #29