### PR TITLE
If build command fails raise a helpful exception

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -46,7 +46,7 @@ else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/Procfile.dev", "Procfile.dev"
 
-  say "Ensure foreman is install"
+  say "Ensure foreman is installed"
   run "gem install foreman"
 end
 

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -1,7 +1,9 @@
 namespace :css do
   desc "Build your CSS bundle"
   task :build do
-    system "yarn install && yarn build:css"
+    unless system "yarn install && yarn build:css"
+      raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors"
+    end
   end
 end
 


### PR DESCRIPTION
Fixes #28 

I’m not sure convention wise if there are better ways of outputting this error message, let me know and I can make adjustments. 

Once sorted I’ll PR a similar change into jsbundling-rails.