### PR TITLE
Add a task to clear builds

### DIFF
--- a/lib/tasks/cssbundling/clean.rake
+++ b/lib/tasks/cssbundling/clean.rake
@@ -1,0 +1,8 @@
+namespace :css do
+  desc "Remove CSS builds"
+  task :clean do
+    rm_rf Dir["app/assets/builds/[^.]*.css"], verbose: false
+  end
+end
+
+Rake::Task["assets:clean"].enhance(["css:clean"])


### PR DESCRIPTION
This task might be useful in development while experimenting with different config, and also in production for services like Heroku that call `assets:clean` task after finishing the build.