### PR TITLE
Make css:build depend on yarn:install directly

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -1,7 +1,7 @@
 namespace :css do
   desc "Build your CSS bundle"
-  task :build do
-    unless system "yarn install && yarn build:css"
+  task build: [ "yarn:install" ] do
+    unless system "yarn build:css"
       raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors"
     end
   end


### PR DESCRIPTION
This PR makes `css:build` depend on `yarn:install` directly instead of running `yarn install` on its own. This ensures `yarn install` is only run once and not multiple times.

Comparable to rails/jsbundling-rails#43 and rails/jsbundling-rails#49.

**This relies on rails/rails#43641** which corrects `yarn:install` to use `yarn` via the PATH and not require `bin/yarn`, which is no longer added in Rails 7.

I believe it's safe to depend on yarn:install directly because cssbundling-rails already depends on railties, so yarn:install should always be available. If this somehow isn't valid, then we could add a no-op version of yarn:install here which would at least avoid errors while also not skipping enhancement as the existing approach does.
