### PR TITLE
Revisit css:build using the yarn:install task

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -1,7 +1,12 @@
 namespace :css do
   desc "Build your CSS bundle"
   task :build do
-    unless system "yarn install && yarn build:css"
+    # yarn:install on Rails 6.x requires bin/yarn
+    unless Rails::VERSION::MAJOR < 7 && !File.exist?('bin/yarn')
+      Rake::Task["yarn:install"].invoke
+    end
+
+    unless system "yarn build:css"
       raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors"
     end
   end


### PR DESCRIPTION
This restores use of the `yarn:install` task from #42, but adds a conditional for Rails 6.x to parallel existing behavior on those Rails versions, which addresses #43.

This does mean that yarn install will be skipped on Rails 6.x if `bin/yarn` doesn't exist, but this was already true for `assets:precompile` with webpacker anyway.

Rails 6.x apps migrating from webpacker will usually have `bin/yarn` already. Apps migrating from just sprockets without webpacker may not, but this should be infrequent. Rails 6.x apps that want yarn install to run automatically can:
a) create `bin/yarn`,
b) add their own task dependency on `yarn:install`, or
c) include `yarn:install` when building css or precompiling: `rails yarn:install build:css` or `rails yarn:install assets:precompile`.

Rails 7 apps will continue to call `yarn:install` automatically, which uses yarn via the PATH and not bin/yarn

Background:
Rails 6.x's `yarn:install` requires `bin/yarn` to exist. If not present, it silently skips adding a dependency on `yarn:install` from `assets:precompile`.

Reasoning:
I think there's still value in using the `yarn:install` task as it performs more than a simple `yarn install`. In addition to ensuring yarn install only runs once (via rake's dependency mechanism), `yarn:install` also sets `NODE_ENV` and adds some flags to the execution. If an app needs to customize `yarn:install`, it also provides a single point to do so.

Another alternative is to remove yarn install entirely and let apps call `yarn:install` on their own (or even `yarn install --custom-flags`), just like they call `bundle install`. Build scripts that still want to use the task could simply add it before precompile, ie: `rails yarn:install assets:precompile`.