### PR TITLE
Update default tailwind.config.js for Tailwind 3

### DIFF
--- a/lib/install/tailwind/tailwind.config.js
+++ b/lib/install/tailwind/tailwind.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  mode: 'jit',
   content: [
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',

--- a/lib/install/tailwind/tailwind.config.js
+++ b/lib/install/tailwind/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   mode: 'jit',
-  purge: [
+  content: [
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',
     './app/javascript/**/*.js'


### PR DESCRIPTION
The `css:install:tailwind` task simply installs the latest version of Tailwind. The new major release of Tailwind has changed from using `purge` to `content`.

We are getting warning if we don't update:

```
warn - The `purge`/`content` options have changed in Tailwind CSS v3.0.
warn - Update your configuration file to eliminate this warning.       
```

Reference:
- [Tailwind 3.0 blog post](https://www.themes.dev/blog/tailwind-css-version-3/#purge-needs-to-be-renamed-to-content)