### PR TITLE
Add stylesheets path to TailwindCSS' content list

### DIFF
--- a/lib/install/tailwind/tailwind.config.js
+++ b/lib/install/tailwind/tailwind.config.js
@@ -2,6 +2,7 @@ module.exports = {
   content: [
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',
+    './app/assets/stylesheets/**/*.css',
     './app/javascript/**/*.js'
   ]
 }


### PR DESCRIPTION
Hi,

While using Rails 7.0.0 with Tailwind I noticed that if I changed my `application.tailwind.css` file, such as adding these lines at the bottom:

```css
body {
  background-color: #00ff00;
}
```

The tailwindcss watcher wasn't picking up the change and it did not produce a new build.

After applying this PR's patch it picks up the changes and it does produce a new build.