### PR TITLE
README clarify javascript:build may also need to be run if test:prepare is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ When you deploy your application to production, the `css:build` task attaches to
 
 This also happens in testing where the bundler attaches to the `test:prepare` task to ensure the stylesheets have been bundled before testing commences. (Note that this currently only applies to rails `test:*` tasks (like `test:all` or `test:controllers`), not "rails test", as that doesn't load `test:prepare`).
 
-If your test framework does not define a `test:prepare` Rake task, ensure that your test framework runs `css:build` to bundle stylesheets before testing commences.
+If your test framework does not define a `test:prepare` Rake task, ensure that your test framework runs `css:build` to bundle stylesheets before testing commences. If your setup uses [jsbundling-rails](https://github.com/rails/jsbundling-rails) (ie, esbuild + tailwind), you will also need to run `javascript:build`.
 
 That's it!
 


### PR DESCRIPTION
When a user invokes `rails test` or uses a test framework that does not define a `test:prepare` Rake task, `css:build` must be run manually. This is already documented in the README.

If `jsbundling-rails` is also being used, `javascript:build` may also need to be run (ie, esbuild + tailwind). 

If either `css:build` or `javascript:build` is required and is not run, minitest reports the same error:
> ActionView::Template::Error: The asset "application.css" is not present in the asset pipeline.

This PR aims to improve the documentation to avoid others chasing their tail for a few hours like I did.