### PR TITLE
Check assets:precompile is defined before enhancing

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -7,7 +7,9 @@ namespace :css do
   end
 end
 
-Rake::Task["assets:precompile"].enhance(["css:build"])
+if Rake::Task.task_defined?("assets:precompile")
+  Rake::Task["assets:precompile"].enhance(["css:build"])
+end
 
 if Rake::Task.task_defined?("test:prepare")
   Rake::Task["test:prepare"].enhance(["css:build"])


### PR DESCRIPTION
a749ca2 suggests that "Sprockets is not a dependency", so we should not
assume that the assets:precompile task will be defined. If it's not
there, we should just skip enhancing it.

Fixes #58