### PR TITLE
Make the message for adding build:css to package.json more visible if npx version is < 7.1

### DIFF
--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -14,7 +14,7 @@ say "Add build:css script"
 build_script = "sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
-  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :green
+  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red
 else
   run %(npm set-script build:css "#{build_script}")
   run %(yarn build:css)

--- a/lib/install/bulma/install.rb
+++ b/lib/install/bulma/install.rb
@@ -7,7 +7,7 @@ say "Add build:css script"
 build_script = "sass ./app/assets/stylesheets/application.bulma.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
-  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :green
+  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red
 else
   run %(npm set-script build:css "#{build_script}")
   run %(yarn build:css)

--- a/lib/install/postcss/install.rb
+++ b/lib/install/postcss/install.rb
@@ -7,7 +7,7 @@ say "Add build:css script"
 build_script = "postcss ./app/assets/stylesheets/application.postcss.css -o ./app/assets/builds/application.css"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
-  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :green
+  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red
 else
   run %(npm set-script build:css "#{build_script}")
   run %(yarn build:css)

--- a/lib/install/sass/install.rb
+++ b/lib/install/sass/install.rb
@@ -6,7 +6,7 @@ say "Add build:css script"
 build_script = "sass ./app/assets/stylesheets/application.sass.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
-  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :green
+  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red
 else
   run %(npm set-script build:css "#{build_script}")
   run %(yarn build:css)

--- a/lib/install/tailwind/install.rb
+++ b/lib/install/tailwind/install.rb
@@ -7,7 +7,7 @@ say "Add build:css script"
 build_script = "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
-  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :green
+  say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red
 else
   run %(npm set-script build:css "#{build_script}")
   run %(yarn build:css)


### PR DESCRIPTION
This makes it more clear what needs to be done.
It is based on the discussion in https://github.com/rails/cssbundling-rails/issues/65