### PR TITLE
Check assets:clobber is defined before enhancing

### DIFF
--- a/lib/tasks/cssbundling/clobber.rake
+++ b/lib/tasks/cssbundling/clobber.rake
@@ -5,4 +5,6 @@ namespace :css do
   end
 end
 
-Rake::Task["assets:clobber"].enhance(["css:clobber"])
+if Rake::Task.task_defined?("assets:clobber")
+  Rake::Task["assets:clobber"].enhance(["css:clobber"])
+end


### PR DESCRIPTION
https://github.com/rails/cssbundling-rails/commit/a749ca29a91ee0b5cbc884b02505631576b09e43 suggests that "Sprockets is not a dependency", so we should not
assume that the assets:precompile AND assets:clobber tasks will be defined. If it's not
there, we should just skip enhancing it.

Related to: https://github.com/rails/cssbundling-rails/pull/59

Fixes issue `Don't know how to build task 'assets:clobber'`

cc @dhh @richardTowers 