### PR TITLE
Check assets:clobber is defined before enhancing

### DIFF
--- a/lib/tasks/cssbundling/clobber.rake
+++ b/lib/tasks/cssbundling/clobber.rake
@@ -5,4 +5,6 @@ namespace :css do
   end
 end
 
-Rake::Task["assets:clobber"].enhance(["css:clobber"])
+if Rake::Task.task_defined?("assets:clobber")
+  Rake::Task["assets:clobber"].enhance(["css:clobber"])
+end


### PR DESCRIPTION
Related to a1d4c6b5e86f0b0da7c9e2a8de506c1497051dc2 and #58.

Now that sprockets is no longer a dependency, my upgrade to Rails 7 got stuck because `assets:clobber` was no longer a defined task in my local Rails app.