### PR TITLE
Install bootstrap-icons along with bootstrap

### DIFF
--- a/lib/install/bootstrap/application.bootstrap.scss
+++ b/lib/install/bootstrap/application.bootstrap.scss
@@ -1,1 +1,2 @@
 @import 'bootstrap/scss/bootstrap';
+@import 'bootstrap-icons/font/bootstrap-icons';

--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -1,7 +1,13 @@
-say "Install Bootstrap with Popperjs/core"
+say "Install Bootstrap with Bootstrap Icons and Popperjs/core"
 copy_file "#{__dir__}/application.bootstrap.scss",
    "app/assets/stylesheets/application.bootstrap.scss"
-run "yarn add sass bootstrap @popperjs/core"
+run "yarn add sass bootstrap bootstrap-icons @popperjs/core"
+
+inject_into_file "config/initializers/assets.rb", after: /.*Rails.application.config.assets.paths.*\n/ do
+  <<~RUBY
+    Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap-icons/font")
+  RUBY
+end
 
 if Rails.root.join("app/javascript/application.js").exist?
   say "Appending Bootstrap JavaScript import to default entry point"


### PR DESCRIPTION
Closes #63 

Adds Bootstrap Icons to Bootstrap install task, which helps start with Bootstrap 5 and Bootstrap Icons as quickly as possible.