### PR TITLE
Change sass cli params to permit multiple build sources

### DIFF
--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -17,7 +17,7 @@ else
 end
 
 say "Add build:css script"
-build_script = "sass ./app/assets/stylesheets/application.bootstrap.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
+build_script = "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
   say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red

--- a/lib/install/bulma/install.rb
+++ b/lib/install/bulma/install.rb
@@ -4,7 +4,7 @@ copy_file "#{__dir__}/application.bulma.scss",
 run "yarn add sass bulma"
 
 say "Add build:css script"
-build_script = "sass ./app/assets/stylesheets/application.bulma.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
+build_script = "sass ./app/assets/stylesheets/application.bulma.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
   say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red

--- a/lib/install/sass/install.rb
+++ b/lib/install/sass/install.rb
@@ -3,7 +3,7 @@ copy_file "#{__dir__}/application.sass.scss", "app/assets/stylesheets/applicatio
 run "yarn add sass"
 
 say "Add build:css script"
-build_script = "sass ./app/assets/stylesheets/application.sass.scss ./app/assets/builds/application.css --no-source-map --load-path=node_modules"
+build_script = "sass ./app/assets/stylesheets/application.sass.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules"
 
 if (`npx -v`.to_f < 7.1 rescue "Missing")
   say %(Add "scripts": { "build:css": "#{build_script}" } to your package.json), :red


### PR DESCRIPTION
So the sass cli allows for multiple sources & outputs, just not using the space syntax. Using the `source:destination` syntax makes this more obvious if a user wanted to bundle multiple sources at once they can just append another into this list.

I'm not sure if this is possible with postcss and tailwind CLIs, if these can be updated as well that'd be great