### PR TITLE
Minor portability improvements to ./bin/dev

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 if ! gem list foreman -i --silent; then
   echo "Installing foreman..."
   gem install foreman
 fi
 
-foreman start -f Procfile.dev "$@"
+exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
This fixes a couple issues we ran into, using small alpine ruby image under docker, developing locally with docker compose:

1. use `exec` to invoke `foreman`. This ensures the `dev` script is replaced by the `foreman` process and  signals/interrupts like <kbd>ctrl</kbd>+<kbd>c</kbd> are handled correctly. Without this, the child `foreman` processes are not stopped gracefully and the PID file not cleaned up.

2. replace `bash` with `sh`. Alpine Linux (for example) ships with `ash` (not `bash`) but includes `sh`, so this seems like a reasonable choice as "lowest common denominator"

---

Gist of minimal test case:

https://gist.github.com/defeated/5d1b7469d5fedb6d6b242f141c68c895