### PR TITLE
Add possibility to skip css:build during assets:precompile

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -7,7 +7,7 @@ namespace :css do
   end
 end
 
-unless ENV['SKIP_CSS_BUILD']
+unless ENV["SKIP_CSS_BUILD"]
   if Rake::Task.task_defined?("assets:precompile")
     Rake::Task["assets:precompile"].enhance(["css:build"])
   end

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -2,17 +2,21 @@ namespace :css do
   desc "Build your CSS bundle"
   task :build do
     unless system "yarn install && yarn build:css"
-      raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors"
+      raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors or use CSS_BUILD=false env variable"
     end
   end
 end
 
-if Rake::Task.task_defined?("assets:precompile")
-  Rake::Task["assets:precompile"].enhance(["css:build"])
-end
+skip_css_build = %w(no false n f).include?(ENV["CSS_BUILD"])
 
-if Rake::Task.task_defined?("test:prepare")
-  Rake::Task["test:prepare"].enhance(["css:build"])
-elsif Rake::Task.task_defined?("db:test:prepare")
-  Rake::Task["db:test:prepare"].enhance(["css:build"])
+unless skip_css_build
+  if Rake::Task.task_defined?("assets:precompile")
+    Rake::Task["assets:precompile"].enhance(["css:build"])
+  end
+
+  if Rake::Task.task_defined?("test:prepare")
+    Rake::Task["test:prepare"].enhance(["css:build"])
+  elsif Rake::Task.task_defined?("db:test:prepare")
+    Rake::Task["db:test:prepare"].enhance(["css:build"])
+  end
 end

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -2,14 +2,12 @@ namespace :css do
   desc "Build your CSS bundle"
   task :build do
     unless system "yarn install && yarn build:css"
-      raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors or use CSS_BUILD=false env variable"
+      raise "cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors or use SKIP_CSS_BUILD env variable"
     end
   end
 end
 
-skip_css_build = %w(no false n f).include?(ENV["CSS_BUILD"])
-
-unless skip_css_build
+unless ENV['SKIP_CSS_BUILD']
   if Rake::Task.task_defined?("assets:precompile")
     Rake::Task["assets:precompile"].enhance(["css:build"])
   end


### PR DESCRIPTION
Hello,

I was playing with a dockerfile like this:

```dockerfile
FROM node:18-alpine as builder
        
WORKDIR /src
COPY package.json /src
COPY yarn.lock /src
RUN yarn install
    
COPY . /src
    
RUN yarn build:css
      
FROM ruby:3.0.4
  
WORKDIR /src

COPY Gemfile .
COPY Gemfile.lock .

RUN bundle install
  
COPY . .
  
COPY --from=builder /src/app/assets/builds/application.css /src/app/assets/builds/
RUN bundle exec rails assets:precompile

EXPOSE 3000

CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]
```

And I was getting this error:

```
Step 16/18 : RUN bundle exec rails assets:precompile
 ---> Running in b268b243b355
sh: 1: yarn: not found
rails aborted!
cssbundling-rails: Command css:build failed, ensure yarn is installed and `yarn build:css` runs without errors or add SKIP_YARN

Tasks: TOP => assets:precompile => css:build
(See full trace by running task with --trace)
```

In this case it makes no sense as the css:build has already be done and the final docker image is free of node/yarn, that's why I'm proposing this `CSS_BUILD=false` similar to `WEBPACKER_PRECOMPILE=false` in https://github.com/rails/webpacker/blob/f1b06c7fd5bc4b7fc7128742d1078466b94af71f/lib/tasks/webpacker/compile.rake#L37 to skip the css:build.

