### PR TITLE
Recursively remove builds in clobber task

### DIFF
--- a/lib/tasks/cssbundling/clobber.rake
+++ b/lib/tasks/cssbundling/clobber.rake
@@ -1,7 +1,7 @@
 namespace :css do
   desc "Remove CSS builds"
   task :clobber do
-    rm_rf Dir["app/assets/builds/[^.]*.css"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.css"], verbose: false
   end
 end
 


### PR DESCRIPTION
Handles builds where there are subdirectories of CSS

Mirror of this JS Bundling PR: https://github.com/rails/jsbundling-rails/pull/126