### PR TITLE
Update css:clobber to also remove sourcemaps

### DIFF
--- a/lib/tasks/cssbundling/clobber.rake
+++ b/lib/tasks/cssbundling/clobber.rake
@@ -1,7 +1,7 @@
 namespace :css do
   desc "Remove CSS builds"
   task :clobber do
-    rm_rf Dir["app/assets/builds/**/[^.]*.css"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.{css,css.map}"], verbose: false
   end
 end
 


### PR DESCRIPTION
Right now, the `CSS:clobber` task **only** removes `.css` files, leaving any sourcemap present in the directory if present.
This change mimics how [jsbundling-rails](https://github.com/rails/jsbundling-rails/blob/main/lib/tasks/jsbundling/clobber.rake#L4) works, and removes both CSS files and sourcemaps from the directory.