### PR TITLE
Default to port 3000 while allowing override

### DIFF
--- a/lib/install/Procfile.dev
+++ b/lib/install/Procfile.dev
@@ -1,2 +1,2 @@
-web: unset PORT && env RUBY_DEBUG_OPEN=true bin/rails server
+web: env RUBY_DEBUG_OPEN=true bin/rails server
 css: yarn build:css --watch

--- a/lib/install/dev
+++ b/lib/install/dev
@@ -5,4 +5,7 @@ if ! gem list foreman -i --silent; then
   gem install foreman
 fi
 
+# Default to port 3000 if not specified
+export PORT="${PORT:-3000}"
+
 exec foreman start -f Procfile.dev "$@"


### PR DESCRIPTION
With this configuration `bin/dev` will use port 3000, but `bin/dev -p 3001` will correctly start the server on port 3001.

Cross-posted from https://github.com/rails/jsbundling-rails/pull/148.