### PR TITLE
Add PostCSS import plugin as default

### DIFF
--- a/lib/install/postcss/install.rb
+++ b/lib/install/postcss/install.rb
@@ -1,7 +1,7 @@
 say "Install PostCSS w/ nesting and autoprefixer"
 copy_file "#{__dir__}/postcss.config.js", "postcss.config.js"
 copy_file "#{__dir__}/application.postcss.css", "app/assets/stylesheets/application.postcss.css"
-run "yarn add postcss postcss-cli postcss-nesting autoprefixer"
+run "yarn add postcss postcss-cli postcss-import postcss-nesting autoprefixer"
 
 say "Add build:css script"
 build_script = "postcss ./app/assets/stylesheets/application.postcss.css -o ./app/assets/builds/application.css"

--- a/lib/install/postcss/postcss.config.js
+++ b/lib/install/postcss/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: [
+    require('postcss-import'),
     require('postcss-nesting'),
     require('autoprefixer'),
   ],


### PR DESCRIPTION
https://github.com/postcss/postcss-import

It felt natural to me to immediately use the @import directive right after installing PostCSS and after fighting a bit with it I realised the plugin wasn't installed so it seemed like it would be a sensible default to have.

Adding the official postcss-import plugin enables the usage of PostCSS's @import directive out of the box so when adding a CSS library (like open-props) or when adding custom stylesheets it works seamlessly.

From the PostCSS-import docs:

> [PostCSS](https://github.com/postcss/postcss) plugin to transform @import rules by inlining content.
This plugin can consume local files, node modules or web_modules. To resolve path of an @import rule, it can look into root directory (by default process.cwd()), web_modules, node_modules or local modules. When importing a module, it will look for index.css or file referenced in package.json in the style or main fields. You can also provide manually multiples paths where to look at.

Note that this is **not** the CSS native @import which didn't work on a vanilla installation of Rails with Propshaft. I'm actually not sure if it's supposed to, to be honest.