### PR TITLE
Suggest defining config.assets.css_compressor = nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ A common issue is that your repository does not contain the output directory use
 
 ### How do I avoid `ActionView::Template::Error: Error: Function rgb is missing argument $green`?
 
-This might happen if your Gemfile.lock contains the legacy `sassc-rails`, which might be need while progressively migrating your project, or which might be a transitive dependency of a gem your project depends on and over which you have no control. In this case, prevent Sprockets from bundling the CSS, as it is now taken care of by this gem. Make sure do this for all environments, not only production, otherwise your test suite may fail.
+This might happen if your Gemfile.lock contains the legacy `sassc-rails`, which might be need while progressively migrating your project, or which might be a transitive dependency of a gem your project depends on and over which you have no control. In this case, prevent Sprockets from bundling the CSS on top of the bundling already performed by this gem. Make sure do this for all environments, not only production, otherwise your test suite may fail.
 
 ```
 # config/initializers/assets.rb

--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ Some CSS packages use new CSS features that are not supported by the default Sas
 
 A common issue is that your repository does not contain the output directory used by the build commands. You must have `app/assets/builds` available. Add the directory with a `.gitkeep` file, and you'll ensure it's available in production.
 
+### How do I avoid `ActionView::Template::Error: Error: Function rgb is missing argument $green`?
+
+This might happen if your Gemfile.lock contains the legacy `sassc-rails`, which might be need while progressively migrating your project, or which might be a transitive dependency of a gem your project depends on and over which you have no control. In this case, prevent Sprockets from bundling the CSS, as it is now taken care of by this gem. Make sure do this for all environments, not only production, otherwise your test suite may fail.
+
+```
+# config/initializers/assets.rb
+Rails.application.config.assets.css_compressor = nil
+```
+
 ### Why isn't Rails using my updated css files?
 
 Watch out - if you precompile your files locally, those will be served over the dynamically created ones you expect. The solution:


### PR DESCRIPTION
We are migrating our project away from sassc-rails towards cssbundling-rails with sass (and in preparation for introducing tailwind in parallel with that while we rewrite everything), however we still use administrate which as of writing [still depends on sassc-rails](https://github.com/thoughtbot/administrate/issues/2311).

At first we defined `config.assets.css_compressor = nil` by uncommenting the line in `config/environments/production.rb`, but only later realized this did not affect the test environment, which is the reason why our test suite was still failing with errors such as `ActionView::Template::Error: Error: Function rgb is missing argument $green`, and I believe other seemingly incomprensible errors such as `ActionView::Template::Error: Asset X was not declared to be precompiled in production` even though they were included in the Sprockets manifest. Perhaps this PR will prevent someone else from encountering the same misfortune.

Additional idea: how about having the gem raise a warning if config.assets.css_compressor is not nil?