### PR TITLE
Namespace helper methods for css:build command

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -1,7 +1,7 @@
 namespace :css do
   desc "Install JavaScript dependencies"
   task :install do
-    command = install_command
+    command = Cssbundling::Tasks.install_command
     unless system(command)
       raise "cssbundling-rails: Command install failed, ensure #{command.split.first} is installed"
     end
@@ -9,7 +9,7 @@ namespace :css do
 
   desc "Build your CSS bundle"
   build_task = task :build do
-    command = build_command
+    command = Cssbundling::Tasks.build_command
     unless system(command)
       raise "cssbundling-rails: Command build failed, ensure `#{command}` runs without errors"
     end
@@ -17,20 +17,26 @@ namespace :css do
   build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
 end
 
-def install_command
-  return "bun install" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
-  return "yarn install" if File.exist?('yarn.lock') || tool_exists?('yarn')
-  raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
-end
+module Cssbundling
+  module Tasks
+    extend self
 
-def build_command
-  return "bun run build:css" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
-  return "yarn build:css" if File.exist?('yarn.lock') || tool_exists?('yarn')
-  raise "cssbundling-rails: No suitable tool found for building CSS"
-end
+    def install_command
+      return "bun install" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
+      return "yarn install" if File.exist?('yarn.lock') || tool_exists?('yarn')
+      raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
+    end
 
-def tool_exists?(tool)
-  system "command -v #{tool} > /dev/null"
+    def build_command
+      return "bun run build:css" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
+      return "yarn build:css" if File.exist?('yarn.lock') || tool_exists?('yarn')
+      raise "cssbundling-rails: No suitable tool found for building CSS"
+    end
+
+    def tool_exists?(tool)
+      system "command -v #{tool} > /dev/null"
+    end
+  end
 end
 
 unless ENV["SKIP_CSS_BUILD"]


### PR DESCRIPTION
Methods defined in Rake files are added to the global namespace. This means `cssbundling-rails` and `jsbundling-rails` using the same `build_command` method name get overridden by one or the other.

This introduces a module to namespace these methods and provides a place for any future methods to be defined. 

Since these only apply to the tasks in `build.rake`, I just defined the module there, but we could extract it to a file and require it instead.

Fixes #131

cc @terracatta 