### PR TITLE
Fix missing extensions on Procfile generation

### DIFF
--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -47,7 +47,7 @@ if Rails.root.join("Procfile.dev").exist?
   append_to_file "Procfile.dev", "css: #{bundler_run_cmd} build:css --watch\n"
 else
   say "Add default Procfile.dev"
-  copy_file "#{__dir__}/#{using_bun? ? "Procfile_for_bun" : "Procfile_for_node"}", "Procfile.dev"
+  copy_file "#{__dir__}/#{using_bun? ? "Procfile_for_bun.dev" : "Procfile_for_node.dev"}", "Procfile.dev"
 
   say "Ensure foreman is installed"
   run "gem install foreman"


### PR DESCRIPTION
Fixes #133.

This was a really silly mistake. 

I forgot to add the file extensions to the file names when switching between bun and node. This is a code path I didn't manually test as I did all my testing in a repo that previously had the jsbundling-rails installer on it (so I always had a Procfile).

### Example Run after I fixed it

```
☁  jason_test_css [main] ⚡  ls Procfile.dev
ls: Procfile.dev: No such file or directory
☁  jason_test_css [main] ⚡  ./bin/rails css:install:bootstrap
       apply  /Users/jmeller/code/terracatta/cssbundling-rails/lib/install/install.rb
  Build into app/assets/builds
      create    app/assets/builds
      create    app/assets/builds/.keep
      append    app/assets/config/manifest.js
  Stop linking stylesheets automatically
        gsub    app/assets/config/manifest.js
      append    .gitignore
      append    .gitignore
  Remove app/assets/stylesheets/application.css so build output can take over
      remove    app/assets/stylesheets/application.css
  Add stylesheet link tag in application layout
File unchanged! Either the supplied flag value not found or the content has already been inserted!    app/views/layouts/application.html.erb
  Add default package.json
      create    package.json
  Add default Procfile.dev
      create    Procfile.dev
  Ensure foreman is installed
         run    gem install foreman from "."
Successfully installed foreman-0.87.2
Parsing documentation for foreman-0.87.2
Done installing documentation for foreman after 0 seconds
1 gem installed
  Add bin/dev to start foreman
      create    bin/dev
         run  bundle install
Using rake 13.0.6
Using base64 0.1.1
Using bigdecimal 3.1.4
Using concurrent-ruby 1.2.2
Using connection_pool 2.4.1
Using ruby2_keywords 0.0.5
Using drb 2.1.1
Using i18n 1.14.1
Using minitest 5.20.0
Using mutex_m 0.1.2
Using tzinfo 2.0.6
Using activesupport 7.1.0.beta1
Using builder 3.2.4
Using erubi 1.12.0
Using racc 1.7.1
Using nokogiri 1.15.4 (arm64-darwin)
Using rails-dom-testing 2.2.0
Using crass 1.0.6
Using loofah 2.21.3
Using rails-html-sanitizer 1.6.0
Using actionview 7.1.0.beta1
Using rack 3.0.8
Using rack-session 2.0.0
Using rack-test 2.1.0
Using actionpack 7.1.0.beta1
Using nio4r 2.5.9
Using websocket-extensions 0.1.5
Using websocket-driver 0.7.6
Using zeitwerk 2.6.11
Using actioncable 7.1.0.beta1
Using globalid 1.2.1
Using activejob 7.1.0.beta1
Using activemodel 7.1.0.beta1
Using timeout 0.4.0
Using activerecord 7.1.0.beta1
Using marcel 1.0.2
Using activestorage 7.1.0.beta1
Using mini_mime 1.1.5
Using date 3.3.3
Using net-protocol 0.2.1
Using net-imap 0.3.7
Using net-pop 0.1.2
Using net-smtp 0.3.3
Using mail 2.8.1
Using actionmailbox 7.1.0.beta1
Using actionmailer 7.1.0.beta1
Using actiontext 7.1.0.beta1
Using public_suffix 5.0.3
Using addressable 2.8.5
Using bindex 0.8.1
Using msgpack 1.7.2
Using bootsnap 1.16.0
Using bundler 2.4.10
Using matrix 0.4.2
Using regexp_parser 2.8.1
Using xpath 3.2.0
Using capybara 3.39.2
Using stringio 3.0.8
Using psych 5.1.0
Using rdoc 6.5.0
Using io-console 0.6.0
Using reline 0.3.8
Using irb 1.8.1
Using webrick 1.8.1
Using rackup 2.1.0
Using thor 1.2.2
Using railties 7.1.0.beta1
Using cssbundling-rails 1.3.1 from source at `/Users/jmeller/code/terracatta/cssbundling-rails`
Using debug 1.8.0
Using error_highlight 0.5.1
Using importmap-rails 1.2.1
Using jbuilder 2.11.5
Using puma 6.3.1
Using rails 7.1.0.beta1
Using rexml 3.2.6
Using rubyzip 2.3.2
Using websocket 1.2.9
Using selenium-webdriver 4.12.0
Using sprockets 4.2.1
Using sprockets-rails 3.4.2
Using sqlite3 1.6.6 (arm64-darwin)
Using stimulus-rails 1.2.2
Using turbo-rails 1.4.0
Using web-console 4.2.1
Bundle complete! 16 Gemfile dependencies, 84 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle lock --add-platform=x86_64-linux
Writing lockfile to /Users/jmeller/code/source/jason_test_css/Gemfile.lock
         run  bundle lock --add-platform=aarch64-linux
Writing lockfile to /Users/jmeller/code/source/jason_test_css/Gemfile.lock
       apply  /Users/jmeller/code/terracatta/cssbundling-rails/lib/install/bootstrap/install.rb
  Install Bootstrap with Bootstrap Icons, Popperjs/core and Autoprefixer
      create    app/assets/stylesheets/application.bootstrap.scss
         run    bun add sass bootstrap bootstrap-icons @popperjs/core postcss postcss-cli autoprefixer nodemon from "."
bun add v1.0.0 (822a00c4)

 installed sass@1.66.1 with binaries:
  - sass
 installed bootstrap@5.3.1
 installed bootstrap-icons@1.11.0
 installed @popperjs/core@2.11.8
 installed postcss@8.4.29
 installed postcss-cli@10.1.0 with binaries:
  - postcss
 installed autoprefixer@10.4.15 with binaries:
  - autoprefixer
 installed nodemon@3.0.1 with binaries:
  - nodemon


 99 packages installed [1487.00ms]
      insert    config/initializers/assets.rb
  Appending Bootstrap JavaScript import to default entry point
      append    app/javascript/application.js
         run    bun run build:css:compile from "."
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
Deprecation Warning: Passing percentage units to the global abs() function is deprecated.
In the future, this will emit a CSS abs() function to be resolved by the browser.
To preserve current behavior: math.abs(100%)
To emit a CSS abs() now: abs(#{100%})
More info: https://sass-lang.com/d/abs-percent

   ╷
57 │   $dividend: abs($dividend);
   │              ^^^^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/vendor/_rfs.scss 57:14         divide()
    node_modules/bootstrap/scss/mixins/_grid.scss 59:12        row-cols()
    node_modules/bootstrap/scss/mixins/_grid.scss 85:13        @content
    node_modules/bootstrap/scss/mixins/_breakpoints.scss 68:5  media-breakpoint-up()
    node_modules/bootstrap/scss/mixins/_grid.scss 72:5         make-grid-columns()
    node_modules/bootstrap/scss/_grid.scss 38:3                @import
    bootstrap/scss/bootstrap.scss 20:9                         @import
    app/assets/stylesheets/application.bootstrap.scss 1:9      root stylesheet

         run    bun run build:css:prefix from "."
$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
         run    bun run build:css from "."
$ bun run build:css:compile && bun run build:css:prefix
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
Deprecation Warning: Passing percentage units to the global abs() function is deprecated.
In the future, this will emit a CSS abs() function to be resolved by the browser.
To preserve current behavior: math.abs(100%)
To emit a CSS abs() now: abs(#{100%})
More info: https://sass-lang.com/d/abs-percent

   ╷
57 │   $dividend: abs($dividend);
   │              ^^^^^^^^^^^^^^
   ╵
    node_modules/bootstrap/scss/vendor/_rfs.scss 57:14         divide()
    node_modules/bootstrap/scss/mixins/_grid.scss 59:12        row-cols()
    node_modules/bootstrap/scss/mixins/_grid.scss 85:13        @content
    node_modules/bootstrap/scss/mixins/_breakpoints.scss 68:5  media-breakpoint-up()
    node_modules/bootstrap/scss/mixins/_grid.scss 72:5         make-grid-columns()
    node_modules/bootstrap/scss/_grid.scss 38:3                @import
    bootstrap/scss/bootstrap.scss 20:9                         @import
    app/assets/stylesheets/application.bootstrap.scss 1:9      root stylesheet

$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
        gsub    Procfile.dev
         run  bundle install
Using rake 13.0.6
Using base64 0.1.1
Using bigdecimal 3.1.4
Using concurrent-ruby 1.2.2
Using connection_pool 2.4.1
Using ruby2_keywords 0.0.5
Using drb 2.1.1
Using i18n 1.14.1
Using minitest 5.20.0
Using mutex_m 0.1.2
Using tzinfo 2.0.6
Using activesupport 7.1.0.beta1
Using builder 3.2.4
Using erubi 1.12.0
Using racc 1.7.1
Using nokogiri 1.15.4 (arm64-darwin)
Using rails-dom-testing 2.2.0
Using crass 1.0.6
Using loofah 2.21.3
Using rails-html-sanitizer 1.6.0
Using actionview 7.1.0.beta1
Using rack 3.0.8
Using rack-session 2.0.0
Using rack-test 2.1.0
Using actionpack 7.1.0.beta1
Using nio4r 2.5.9
Using websocket-extensions 0.1.5
Using websocket-driver 0.7.6
Using zeitwerk 2.6.11
Using actioncable 7.1.0.beta1
Using globalid 1.2.1
Using activejob 7.1.0.beta1
Using activemodel 7.1.0.beta1
Using timeout 0.4.0
Using activerecord 7.1.0.beta1
Using marcel 1.0.2
Using activestorage 7.1.0.beta1
Using mini_mime 1.1.5
Using date 3.3.3
Using net-protocol 0.2.1
Using net-imap 0.3.7
Using net-pop 0.1.2
Using net-smtp 0.3.3
Using mail 2.8.1
Using actionmailbox 7.1.0.beta1
Using actionmailer 7.1.0.beta1
Using actiontext 7.1.0.beta1
Using public_suffix 5.0.3
Using addressable 2.8.5
Using bindex 0.8.1
Using msgpack 1.7.2
Using bootsnap 1.16.0
Using bundler 2.4.10
Using matrix 0.4.2
Using regexp_parser 2.8.1
Using xpath 3.2.0
Using capybara 3.39.2
Using stringio 3.0.8
Using psych 5.1.0
Using rdoc 6.5.0
Using io-console 0.6.0
Using reline 0.3.8
Using irb 1.8.1
Using webrick 1.8.1
Using rackup 2.1.0
Using thor 1.2.2
Using railties 7.1.0.beta1
Using cssbundling-rails 1.3.1 from source at `/Users/jmeller/code/terracatta/cssbundling-rails`
Using debug 1.8.0
Using error_highlight 0.5.1
Using importmap-rails 1.2.1
Using jbuilder 2.11.5
Using puma 6.3.1
Using rails 7.1.0.beta1
Using rexml 3.2.6
Using rubyzip 2.3.2
Using websocket 1.2.9
Using selenium-webdriver 4.12.0
Using sprockets 4.2.1
Using sprockets-rails 3.4.2
Using sqlite3 1.6.6 (arm64-darwin)
Using stimulus-rails 1.2.2
Using turbo-rails 1.4.0
Using web-console 4.2.1
Bundle complete! 16 Gemfile dependencies, 84 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
         run  bundle lock --add-platform=x86_64-linux
Writing lockfile to /Users/jmeller/code/source/jason_test_css/Gemfile.lock
         run  bundle lock --add-platform=aarch64-linux
Writing lockfile to /Users/jmeller/code/source/jason_test_css/Gemfile.lock
```