### PR TITLE
Fix escape double quotes on bootstrap install script

### DIFF
--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -22,7 +22,7 @@ end
 add_package_json_script("build:css:compile", "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules")
 add_package_json_script("build:css:prefix", "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css")
 add_package_json_script("build:css", "#{bundler_run_cmd} build:css:compile && #{bundler_run_cmd} build:css:prefix")
-add_package_json_script("watch:css", "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"#{bundler_run_cmd} build:css\"", false)
+add_package_json_script("watch:css", "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \\\"#{bundler_run_cmd} build:css\\\"", false)
 
 gsub_file "Procfile.dev", "build:css --watch", "watch:css"
 


### PR DESCRIPTION
Fixes error on creation of a new app using -css bootstrap flag or ./bin/rails css:install:bootstrap

**Rails output before this fix**

```
Build into app/assets/builds
       exist  app/assets/builds
   identical  app/assets/builds/.keep
File unchanged! Either the supplied flag value not found or the content has already been inserted!  app/assets/config/manifest.js
Stop linking stylesheets automatically
        gsub  app/assets/config/manifest.js
File unchanged! Either the supplied flag value not found or the content has already been inserted!  .gitignore
File unchanged! Either the supplied flag value not found or the content has already been inserted!  .gitignore
Remove app/assets/stylesheets/application.css so build output can take over
      remove  app/assets/stylesheets/application.css
Add stylesheet link tag in application layout
File unchanged! Either the supplied flag value not found or the content has already been inserted!  app/views/layouts/application.html.erb
      append  Procfile.dev
Add bin/dev to start foreman
   identical  bin/dev
Install Bootstrap with Bootstrap Icons, Popperjs/core and Autoprefixer
   identical  app/assets/stylesheets/application.bootstrap.scss
         run  yarn add sass bootstrap bootstrap-icons @popperjs/core postcss postcss-cli autoprefixer nodemon from "."
yarn add v1.22.19
warning ../../../package.json: No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved 8 new dependencies.
info Direct dependencies
├─ @popperjs/core@2.11.8
├─ autoprefixer@10.4.15
├─ bootstrap-icons@1.11.0
├─ bootstrap@5.3.2
├─ nodemon@3.0.1
├─ postcss-cli@10.1.0
├─ postcss@8.4.29
└─ sass@1.67.0
info All dependencies
├─ @popperjs/core@2.11.8
├─ autoprefixer@10.4.15
├─ bootstrap-icons@1.11.0
├─ bootstrap@5.3.2
├─ nodemon@3.0.1
├─ postcss-cli@10.1.0
├─ postcss@8.4.29
└─ sass@1.67.0
✨  Done in 3.72s.
File unchanged! Either the supplied flag value not found or the content has already been inserted!  config/initializers/assets.rb
Appending Bootstrap JavaScript import to default entry point
File unchanged! Either the supplied flag value not found or the content has already been inserted!  app/javascript/application.js
Add build:css:compile script
         run  npm pkg set scripts.build:css:compile="sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules" from "."
         run  yarn build:css:compile from "."
yarn run v1.22.19
warning ../../../package.json: No license field
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
✨  Done in 2.77s.
Add build:css:prefix script
         run  npm pkg set scripts.build:css:prefix="postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css" from "."
         run  yarn build:css:prefix from "."
yarn run v1.22.19
warning ../../../package.json: No license field
$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
✨  Done in 1.40s.
Add build:css script
         run  npm pkg set scripts.build:css="yarn build:css:compile && yarn build:css:prefix" from "."
         run  yarn build:css from "."
yarn run v1.22.19
warning ../../../package.json: No license field
$ yarn build:css:compile && yarn build:css:prefix
warning ../../../package.json: No license field
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
warning ../../../package.json: No license field
$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
✨  Done in 4.44s.
Add watch:css script
         run  npm pkg set scripts.watch:css="nodemon --watch ./app/assets/stylesheets/ --ext scss --exec "yarn build:css"" from "."
npm ERR! code EUSAGE
npm ERR! 
npm ERR! npm pkg set expects a key=value pair of args.
npm ERR! 
npm ERR! Manages your package.json
npm ERR! 
npm ERR! Usage:
npm ERR! npm pkg set <key>=<value> [<key>=<value> ...]
npm ERR! npm pkg get [<key> [<key> ...]]
npm ERR! npm pkg delete <key> [<key> ...]
npm ERR! npm pkg set [<array>[<index>].<key>=<value> ...]
npm ERR! npm pkg set [<array>[].<key>=<value> ...]
npm ERR! npm pkg fix
npm ERR! 
npm ERR! Options:
npm ERR! [-f|--force] [--json]
npm ERR! [-w|--workspace <workspace-name> [-w|--workspace <workspace-name> ...]]
npm ERR! [-ws|--workspaces]
npm ERR! 
npm ERR! Run "npm help pkg" for more info

npm ERR! A complete log of this run can be found in: /Users/wellington/.npm/_logs/2023-09-16T00_17_17_111Z-debug-0.log
        gsub  Procfile.dev
```

**Rails output after this fix**

```
Build into app/assets/builds
       exist  app/assets/builds
   identical  app/assets/builds/.keep
File unchanged! Either the supplied flag value not found or the content has already been inserted!  app/assets/config/manifest.js
Stop linking stylesheets automatically
        gsub  app/assets/config/manifest.js
File unchanged! Either the supplied flag value not found or the content has already been inserted!  .gitignore
File unchanged! Either the supplied flag value not found or the content has already been inserted!  .gitignore
Remove app/assets/stylesheets/application.css so build output can take over
      remove  app/assets/stylesheets/application.css
Add stylesheet link tag in application layout
File unchanged! Either the supplied flag value not found or the content has already been inserted!  app/views/layouts/application.html.erb
      append  Procfile.dev
Add bin/dev to start foreman
   identical  bin/dev
Install Bootstrap with Bootstrap Icons, Popperjs/core and Autoprefixer
   identical  app/assets/stylesheets/application.bootstrap.scss
         run  yarn add sass bootstrap bootstrap-icons @popperjs/core postcss postcss-cli autoprefixer nodemon from "."
yarn add v1.22.19
warning ../../../package.json: No license field
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved 8 new dependencies.
info Direct dependencies
├─ @popperjs/core@2.11.8
├─ autoprefixer@10.4.15
├─ bootstrap-icons@1.11.0
├─ bootstrap@5.3.2
├─ nodemon@3.0.1
├─ postcss-cli@10.1.0
├─ postcss@8.4.29
└─ sass@1.67.0
info All dependencies
├─ @popperjs/core@2.11.8
├─ autoprefixer@10.4.15
├─ bootstrap-icons@1.11.0
├─ bootstrap@5.3.2
├─ nodemon@3.0.1
├─ postcss-cli@10.1.0
├─ postcss@8.4.29
└─ sass@1.67.0
✨  Done in 3.77s.
File unchanged! Either the supplied flag value not found or the content has already been inserted!  config/initializers/assets.rb
Appending Bootstrap JavaScript import to default entry point
File unchanged! Either the supplied flag value not found or the content has already been inserted!  app/javascript/application.js
Add build:css:compile script
         run  npm pkg set scripts.build:css:compile="sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules" from "."
         run  yarn build:css:compile from "."
yarn run v1.22.19
warning ../../../package.json: No license field
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
✨  Done in 2.75s.
Add build:css:prefix script
         run  npm pkg set scripts.build:css:prefix="postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css" from "."
         run  yarn build:css:prefix from "."
yarn run v1.22.19
warning ../../../package.json: No license field
$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
✨  Done in 1.38s.
Add build:css script
         run  npm pkg set scripts.build:css="yarn build:css:compile && yarn build:css:prefix" from "."
         run  yarn build:css from "."
yarn run v1.22.19
warning ../../../package.json: No license field
$ yarn build:css:compile && yarn build:css:prefix
warning ../../../package.json: No license field
$ sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules
warning ../../../package.json: No license field
$ postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css
✨  Done in 4.42s.
Add watch:css script
         run  npm pkg set scripts.watch:css="nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\"" from "."
        gsub  Procfile.dev
```

