### PR TITLE
Introduce `modern-normalize` for `postcss` and `sass` installs

### DIFF
--- a/lib/install/postcss/application.postcss.css
+++ b/lib/install/postcss/application.postcss.css
@@ -1,1 +1,2 @@
 /* Entry point for your PostCSS build */
+@import "modern-normalize";

--- a/lib/install/postcss/install.rb
+++ b/lib/install/postcss/install.rb
@@ -4,7 +4,7 @@ self.extend Helpers
 say "Install PostCSS w/ nesting and autoprefixer"
 copy_file "#{__dir__}/postcss.config.js", "postcss.config.js"
 copy_file "#{__dir__}/application.postcss.css", "app/assets/stylesheets/application.postcss.css"
-run "#{bundler_cmd} add postcss postcss-cli postcss-import postcss-nesting autoprefixer"
+run "#{bundler_cmd} add postcss postcss-cli postcss-import postcss-nesting autoprefixer modern-normalize"
 
 say "Add build:css script"
 add_package_json_script "build:css",

--- a/lib/install/sass/application.sass.scss
+++ b/lib/install/sass/application.sass.scss
@@ -1,1 +1,2 @@
 // Entry point for your Sass build
+@import "modern-normalize/modern-normalize";

--- a/lib/install/sass/install.rb
+++ b/lib/install/sass/install.rb
@@ -3,7 +3,7 @@ self.extend Helpers
 
 say "Install Sass"
 copy_file "#{__dir__}/application.sass.scss", "app/assets/stylesheets/application.sass.scss"
-run "#{bundler_cmd} add sass"
+run "#{bundler_cmd} add sass modern-normalize"
 
 say "Add build:css script"
 add_package_json_script "build:css",


### PR DESCRIPTION
Adds [modern-normalize][] to `postcss` and `sass` installation scripts in an effort to improve the developer experience.

This is consistent with the existing decision to include [autoprefixer][] with the `postcss` installation script.

We chose [modern-normalize][] over [Normalize.css][] due to that fact that it is actively maintained and is used in [Tailwind][].

## How to review this pull-request

1. Create a new rails app without specifying a `--css` option:

    ```
    rails new cssbundling_demo
    ```
1. Add the gem referencing this fork.

    ```ruby
    gem "cssbundling-rails", github: "stevepolitodesign/cssbundling-rails", branch: "sp-modern-normalize"
    ```
1. Run the installation script for either `postcss` or `sass`.

    ```
    bin/rails css:install:[postcss|sass]
    ```
1. Confirm the styles are compiled to `app/assets/builds/application.css`

    ```
    yarn build:css
    cat app/assets/builds/application.css
    ```

[modern-normalize]: https://github.com/sindresorhus/modern-normalize
[autoprefixer]: https://github.com/postcss/autoprefixer
[Normalize.css]: https://github.com/csstools/normalize.css
[Tailwind]: https://tailwindcss.com/docs/preflight