### PR TITLE
PNPM Support

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -25,6 +25,7 @@ module Cssbundling
       case tool
       when :bun then "bun install"
       when :yarn then "yarn install"
+      when :pnpm then "pnpm install"
       when :npm then "npm install"
       else raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
       end
@@ -34,6 +35,7 @@ module Cssbundling
       case tool
       when :bun then "bun run build:css"
       when :yarn then "yarn build:css"
+      when :pnpm then "pnpm build:css"
       when :npm then "npm run build:css"
       else raise "cssbundling-rails: No suitable tool found for building CSS"
       end
@@ -43,9 +45,11 @@ module Cssbundling
       case
       when File.exist?('bun.lockb') then :bun
       when File.exist?('yarn.lock') then :yarn
+      when File.exist?('pnpm-lock.yaml') then :pnpm
       when File.exist?('package-lock.json') then :npm
       when tool_exists?('bun') then :bun
       when tool_exists?('yarn') then :yarn
+      when tool_exists?('pnpm') then :pnpm
       when tool_exists?('npm') then :npm
       end
     end

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -22,15 +22,28 @@ module Cssbundling
     extend self
 
     def install_command
-      return "bun install" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
-      return "yarn install" if File.exist?('yarn.lock') || tool_exists?('yarn')
-      raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
+      case tool
+      when :bun then "bun install"
+      when :yarn then "yarn install"
+      else raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
+      end
     end
 
     def build_command
-      return "bun run build:css" if File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
-      return "yarn build:css" if File.exist?('yarn.lock') || tool_exists?('yarn')
-      raise "cssbundling-rails: No suitable tool found for building CSS"
+      case tool
+      when :bun then "bun run build:css"
+      when :yarn then "yarn build:css"
+      else raise "cssbundling-rails: No suitable tool found for building CSS"
+      end
+    end
+
+    def tool
+      case
+      when File.exist?('bun.lockb') then :bun
+      when File.exist?('yarn.lock') then :yarn
+      when tool_exists?('bun') then :bun
+      when tool_exists?('yarn') then :yarn
+      end
     end
 
     def tool_exists?(tool)

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -25,6 +25,7 @@ module Cssbundling
       case tool
       when :bun then "bun install"
       when :yarn then "yarn install"
+      when :npm then "npm install"
       else raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
       end
     end
@@ -33,6 +34,7 @@ module Cssbundling
       case tool
       when :bun then "bun run build:css"
       when :yarn then "yarn build:css"
+      when :npm then "npm run build:css"
       else raise "cssbundling-rails: No suitable tool found for building CSS"
       end
     end
@@ -41,8 +43,10 @@ module Cssbundling
       case
       when File.exist?('bun.lockb') then :bun
       when File.exist?('yarn.lock') then :yarn
+      when File.exist?('package-lock.json') then :npm
       when tool_exists?('bun') then :bun
       when tool_exists?('yarn') then :yarn
+      when tool_exists?('npm') then :npm
       end
     end
 


### PR DESCRIPTION
[PNPM](https://pnpm.io) is fairly quick / avoids some of the huge `node_module` issues associated with NPM direct usage. It also mirrors the PR for jsbundling-rails: https://github.com/rails/jsbundling-rails/pull/181