### PR TITLE
Use Thor's `apply` instead of a prerequisite task

### DIFF
--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -1,6 +1,8 @@
 require_relative "../helpers"
 self.extend Helpers
 
+apply "#{__dir__}/../install.rb"
+
 say "Install Bootstrap with Bootstrap Icons, Popperjs/core and Autoprefixer"
 copy_file "#{__dir__}/application.bootstrap.scss",
    "app/assets/stylesheets/application.bootstrap.scss"

--- a/lib/install/bulma/install.rb
+++ b/lib/install/bulma/install.rb
@@ -1,6 +1,8 @@
 require_relative "../helpers"
 self.extend Helpers
 
+apply "#{__dir__}/../install.rb"
+
 say "Install Bulma"
 copy_file "#{__dir__}/application.bulma.scss",
    "app/assets/stylesheets/application.bulma.scss"

--- a/lib/install/postcss/install.rb
+++ b/lib/install/postcss/install.rb
@@ -1,6 +1,8 @@
 require_relative "../helpers"
 self.extend Helpers
 
+apply "#{__dir__}/../install.rb"
+
 say "Install PostCSS w/ nesting and autoprefixer"
 copy_file "#{__dir__}/postcss.config.js", "postcss.config.js"
 copy_file "#{__dir__}/application.postcss.css", "app/assets/stylesheets/application.postcss.css"

--- a/lib/install/sass/install.rb
+++ b/lib/install/sass/install.rb
@@ -1,6 +1,8 @@
 require_relative "../helpers"
 self.extend Helpers
 
+apply "#{__dir__}/../install.rb"
+
 say "Install Sass"
 copy_file "#{__dir__}/application.sass.scss", "app/assets/stylesheets/application.sass.scss"
 run "#{bundler_cmd} add sass"

--- a/lib/install/tailwind/install.rb
+++ b/lib/install/tailwind/install.rb
@@ -1,6 +1,8 @@
 require_relative "../helpers"
 self.extend Helpers
 
+apply "#{__dir__}/../install.rb"
+
 say "Install Tailwind (+PostCSS w/ autoprefixer)"
 copy_file "#{__dir__}/tailwind.config.js", "tailwind.config.js"
 copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.tailwind.css"

--- a/lib/tasks/cssbundling/install.rake
+++ b/lib/tasks/cssbundling/install.rake
@@ -1,32 +1,27 @@
 namespace :css do
   namespace :install do
-    desc "Install shared elements for all bundlers"
-    task :shared do
-      system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/install.rb",  __dir__)}"
-    end
-
     desc "Install Tailwind"
-    task tailwind: "css:install:shared" do
+    task :tailwind do
       system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/tailwind/install.rb",  __dir__)}"
     end
 
     desc "Install PostCSS"
-    task postcss: "css:install:shared" do
+    task :postcss do
       system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/postcss/install.rb",  __dir__)}"
     end
 
     desc "Install Sass"
-    task sass: "css:install:shared" do
+    task :sass do
       system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/sass/install.rb",  __dir__)}"
     end
 
     desc "Install Bootstrap"
-    task bootstrap: "css:install:shared" do
+    task :bootstrap do
       system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/bootstrap/install.rb",  __dir__)}"
     end
 
     desc "Install Bulma"
-    task bulma: "css:install:shared" do
+    task :bulma do
       system "#{RbConfig.ruby} ./bin/rails app:template LOCATION=#{File.expand_path("../../install/bulma/install.rb",  __dir__)}"
     end
   end


### PR DESCRIPTION
The `css:install:shared` task serves only as a prerequisite for the other installer tasks; it should not be run on its own (nor listed with `rake --tasks`).  By replacing this task with corresponding calls to Thor's `apply` method, we avoid the overhead of running `bin/rails app:template` (and `bundle install`) multiple times.

---

As a point of comparison, running the tests from #149 without this PR:

  ```console
  $ time bundle exec appraisal rake test

  real  1m3.454s
  user  11m54.481s
  sys   2m39.424s
  ```

And running them with this PR:

  ```console
  $ time bundle exec appraisal rake test

  real  0m43.129s
  user  7m49.613s
  sys   1m48.380s
  ```
