### PR TITLE
Synchronize bin/dev from jsbundling-rails to cssbundling-rails

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-if ! gem list foreman -i --silent; then
+if gem list --no-installed --exact --silent foreman; then
   echo "Installing foreman..."
   gem install foreman
 fi


### PR DESCRIPTION
There are different bin/dev being generated by cssbundling-rails and jsbundling-rails

See https://github.com/rails/jsbundling-rails/pull/174

> dev: Use an affirmative conditional
>
> ...and avoid regex in match.
>
> (Try a gem list ails vs a gem list --exact ails to see what I mean.)