### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/cssbundling-rails

### DIFF
--- a/cssbundling-rails.gemspec
+++ b/cssbundling-rails.gemspec
@@ -12,4 +12,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["lib/**/*", "MIT-LICENSE", "README.md"]
 
   spec.add_dependency "railties", ">= 6.0.0"
+
+  spec.metadata["changelog_uri"] = spec.homepage + "/releases"
 end


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/cssbundling-rails which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/