### PR TITLE
Disable loading .env file when running foreman for development

### DIFF
--- a/lib/install/dev
+++ b/lib/install/dev
@@ -8,4 +8,4 @@ fi
 # Default to port 3000 if not specified
 export PORT="${PORT:-3000}"
 
-exec foreman start -f Procfile.dev "$@"
+exec foreman start -f Procfile.dev --env /dev/null "$@"


### PR DESCRIPTION
TL;DR;

This PR fixes the problem that when a `RAILS_MASTER_KEY` is defined with the key for production in `.env` (which is the case when using Kamal for deployment), the script in `bin/dev` will start foreman which will then pick up the variables from `.env` leading to a `ActiveSupport::MessageEncryptor::InvalidMessage` error when running `bin/dev`

Kamal is added by default for new Rails apps >= v8 (see https://github.com/rails/rails/pull/51798). Although, it seems that is not fully initialized and the `.env` file generated by `kamal init` is removed when a new Rails app is generated.

-- 

There are several other problems with the `.env` approach of Kamal, so I'm not entirely sure if this PR is the "correct" fix, but is seems reasonable as `bin/dev` is only run locally to start bundling + rails.

See other:
- https://github.com/rails/rails/issues/51829 (Original issue/PR leading to this PR)
- https://github.com/ddollar/foreman/issues/702 (Foreman issue describing the `--env /dev/null` solution)
- https://github.com/basecamp/kamal/discussions/617 (Discussion explaining why `.env` in Kamal is dangerous)
- https://github.com/basecamp/kamal/issues/233 (Issue about supporting multiple environments in Kamal)
- https://github.com/basecamp/kamal/discussions/420 (Another discussion about Foreman & Kamal/MRSK incompatibility)