### PR TITLE
Fixes a couple minor issues with bootstrap out of the box

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -23,15 +23,15 @@ end
 
 if Rails.root.join("config/importmap.rb").exist?
   say "Pin Bootstrap"
-  append_to_file "config/importmap.rb", %(pin "bootstrap", to: "bootstrap.min.js"\n)
+  append_to_file "config/importmap.rb", %(pin "bootstrap", to: "bootstrap.bundle.min.js"\n)
 
-  inject_into_file "config/initializers/assets.rb", after: /.*Rails.application.config.assets.paths.*\n/ do
+  inject_into_file "config/initializers/assets.rb", after: /.*\/bootstrap-icons\/font.*\n/ do
     <<~RUBY
       Rails.application.config.assets.paths << Rails.root.join("node_modules/bootstrap/dist/js")
     RUBY
   end
 
-  append_to_file "config/initializers/assets.rb", %(Rails.application.config.assets.precompile << "bootstrap.min.js")
+  append_to_file "config/initializers/assets.rb", %(Rails.application.config.assets.precompile << "bootstrap.bundle.min.js")
 end
 
 add_package_json_script("build:css:compile", "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules")


### PR DESCRIPTION
1. The `bootstrap.min.js` doesn't include all the dependencies, and consequently does not work out of the box. Adding `@popperjs/core` isn't straightforward. However `bootstrap.bundle.min.js` does include what's needed for the quick path of getting up.
1. The asset path to the bootstrap/dist/js directory is added twice. While it does not seem to negatively impact things - it's cleaner to ensure it's done once so we add it after the bootstrap icons we added instead.