### PR TITLE
Add support for yarnpkg

### DIFF
--- a/lib/install/helpers.rb
+++ b/lib/install/helpers.rb
@@ -2,11 +2,23 @@ require 'json'
 
 module Helpers
   def bundler_cmd
-    using_bun? ? "bun" : "yarn"
+    if using_bun?
+      "bun"
+    elsif tool_exists?('yarnpkg')
+      "yarnpkg"
+    else
+      "yarn"
+    end
   end
 
   def bundler_run_cmd
-    using_bun? ? "bun run" : "yarn"
+    if using_bun?
+      "bun"
+    elsif tool_exists?('yarnpkg')
+      "yarnpkg"
+    else
+      "yarn"
+    end
   end
 
   def using_bun?
@@ -29,11 +41,11 @@ module Helpers
       when 7.1...8.0
         say "Add #{name} script"
         run %(npm set-script #{name} "#{script}")
-        run %(yarn #{name}) if run_script
+        tool_exists?("yarnpkg") ? (run %(yarnpkg #{name}) if run_script) : (run %(yarn #{name}) if run_script)
       when (8.0..)
         say "Add #{name} script"
         run %(npm pkg set scripts.#{name}="#{script}")
-        run %(yarn #{name}) if run_script
+        tool_exists?("yarnpkg") ? (run %(yarnpkg #{name}) if run_script) : (run %(yarn #{name}) if run_script)
       else
         say %(Add "scripts": { "#{name}": "#{script}" } to your package.json), :green
       end

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -25,6 +25,7 @@ module Cssbundling
       case tool
       when :bun then "bun install"
       when :yarn then "yarn install"
+      when :yarnpkg then "yarnpkg install"
       when :pnpm then "pnpm install"
       when :npm then "npm install"
       else raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
@@ -35,6 +36,7 @@ module Cssbundling
       case tool
       when :bun then "bun run build:css"
       when :yarn then "yarn build:css"
+      when :yarnpkg then "yarnpkg build:css"
       when :pnpm then "pnpm build:css"
       when :npm then "npm run build:css"
       else raise "cssbundling-rails: No suitable tool found for building CSS"
@@ -44,11 +46,11 @@ module Cssbundling
     def tool
       case
       when File.exist?('bun.lockb') then :bun
-      when File.exist?('yarn.lock') then :yarn
       when File.exist?('pnpm-lock.yaml') then :pnpm
       when File.exist?('package-lock.json') then :npm
       when tool_exists?('bun') then :bun
       when tool_exists?('yarn') then :yarn
+      when tool_exists?('yarnpkg') then :yarnpkg
       when tool_exists?('pnpm') then :pnpm
       when tool_exists?('npm') then :npm
       end


### PR DESCRIPTION
Debian and derivates have yarn packaged as yarnpkg. When cssbundling-rails run in such a system, it could not detect apt installed yarn currently, as the executable is named `yarnpkg` (since there was another yarn executable already). This PR adds the capability for cssbunding-rails to work with yarnpkg as well as yarn. [ruby-cssbundling-rails  package in debian](https://packages.debian.org/search?keywords=ruby-cssbundling-rails) is already shipped with this [patch](https://sources.debian.org/src/ruby-cssbundling-rails/1.4.1-1/debian/patches/add-yarnpkg-support.patch/), and is it what the gitlab package utilizes to work with yarnpkg. Merging this would help with having to carry this patch downstream.

One caveat here is that since yarn and yarnpkg are not different except in names, they both use the same yarn.lock. This means there can't be a convenient "yarn.lock" => "yarn" detection available, but I believe it is worth the tradeoff. I am no ruby wizard, so it is possible that I have missed out on other details and/or checks, so review and inputs are much welcome.