### PR TITLE
Update for Tailwind CSS v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This also happens in testing where the bundler attaches to the `test:prepare` ta
 
 That's it!
 
-You can configure your bundler options in the `build:css` script in `package.json` or via the installer-generated `tailwind.config.js` for Tailwind or `postcss.config.js` for PostCSS.
-
+You can configure your bundler options in the `build:css` script in `package.json` or `postcss.config.js` for PostCSS.
 
 ## Installation
 
@@ -34,7 +33,13 @@ In Rails 7+, you can preconfigure your new application to use `tailwindcss-rails
 
 ### How do I import relative CSS files with Tailwind?
 
-If you want to use `@import` statements as part of your Tailwind application.js file, you need to [configure Tailwind to use `postcss` and then `postcss-import`](https://tailwindcss.com/docs/using-with-preprocessors#build-time-imports). But you should also consider simply referring to your other CSS files directly, instead of bundling them all into one big file. It's better for caching, and it's simpler to setup. You can refer to other CSS files by expanding the `stylesheet_link_tag` in `application.html.erb` like so: `<%= stylesheet_link_tag "application", "other", "styles", "data-turbo-track": "reload" %>`.
+Tailwind CSS 4 is configured using native CSS. Instead of bundling all your CSS into a single file, consider referencing individual CSS files directly. This approach simplifies setup and improves caching performance. To reference multiple CSS files in Rails, update the stylesheet_link_tag in application.html.erb like this:
+
+```erb
+<%= stylesheet_link_tag "application", "other", "styles", "data-turbo-track": "reload" %>
+```
+
+This ensures your files are properly linked and ready to use.
 
 ### How do I avoid SassC::SyntaxError exceptions on existing projects?
 
@@ -58,7 +63,7 @@ Rails.application.config.assets.css_compressor = nil
 Watch out - if you precompile your files locally, those will be served over the dynamically created ones you expect. The solution:
 
 ```shell
-rails assets:clobber 
+rails assets:clobber
 ```
 
 ### How do I include 3rd party stylesheets from `node_modules` in my bundle?

--- a/lib/install/tailwind/application.tailwind.css
+++ b/lib/install/tailwind/application.tailwind.css
@@ -1,3 +1,1 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";

--- a/lib/install/tailwind/install.rb
+++ b/lib/install/tailwind/install.rb
@@ -3,11 +3,10 @@ self.extend Helpers
 
 apply "#{__dir__}/../install.rb"
 
-say "Install Tailwind (+PostCSS w/ autoprefixer)"
-copy_file "#{__dir__}/tailwind.config.js", "tailwind.config.js"
+say "Install Tailwind"
 copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.tailwind.css"
-run "#{bundler_cmd} add tailwindcss@latest postcss@latest autoprefixer@latest"
+run "#{bundler_cmd} add tailwindcss@latest @tailwindcss/cli@latest"
 
 say "Add build:css script"
 add_package_json_script "build:css",
-  "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
+  "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"

--- a/lib/install/tailwind/package.json
+++ b/lib/install/tailwind/package.json
@@ -2,6 +2,6 @@
   "name": "app",
   "private": "true",
   "scripts": {
-    "build:css": "tailwindcss -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css"
+    "build:css": "npx @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css"
   }
 }

--- a/lib/install/tailwind/tailwind.config.js
+++ b/lib/install/tailwind/tailwind.config.js
@@ -1,8 +1,0 @@
-module.exports = {
-  content: [
-    './app/views/**/*.html.erb',
-    './app/helpers/**/*.rb',
-    './app/assets/stylesheets/**/*.css',
-    './app/javascript/**/*.js'
-  ]
-}


### PR DESCRIPTION
This is a pull request based on #163 

Tailwind CSS v4 has new configurations and build scripts simpler than v3 and prior. This updates the installer for Tailwind to include those changes.

Summary:
- Removes `tailwind.config.js` file
- Swaps legacy `@tailwind` directives for normal `@import "tailwindcss"` support.
- Uses `npx` and `@tailwindcss/cli` to build css
- Update README

Let me know if you see any red flags!