### PR TITLE
Improve package manager detection for Bun 1.2 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/lib/install/helpers.rb
+++ b/lib/install/helpers.rb
@@ -10,7 +10,9 @@ module Helpers
   end
 
   def using_bun?
-    File.exist?('bun.lockb') || (tool_exists?('bun') && !File.exist?('yarn.lock'))
+    tool_exists?('bun') && (File.exist?('bun.lockb') || 
+                            File.exist?('bun.lock') ||       
+                            File.exist?('yarn.lock'))
   end
 
   def tool_exists?(tool)

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -21,6 +21,13 @@ module Cssbundling
   module Tasks
     extend self
 
+    LOCK_FILES = {
+      bun: %w[bun.lockb bun.lock yarn.lock],
+      yarn: %w[yarn.lock],
+      pnpm: %w[pnpm-lock.yaml],
+      npm: %w[package-lock.json]
+    }
+
     def install_command
       case tool
       when :bun then "bun install"
@@ -33,29 +40,18 @@ module Cssbundling
 
     def build_command
       case tool
-      when :bun then "bun run build:css"
-      when :yarn then "yarn build:css"
-      when :pnpm then "pnpm build:css"
-      when :npm then "npm run build:css"
+      when using_tool?(:bun) then "bun run build:css"
+      when using_tool?(:yarn) then "yarn build:css"
+      when using_tool?(:pnpm) then "pnpm build:css"
+      when using_tool?(:npm) then "npm run build:css"
       else raise "cssbundling-rails: No suitable tool found for building CSS"
       end
     end
 
-    def tool
-      case
-      when File.exist?('bun.lockb') then :bun
-      when File.exist?('yarn.lock') then :yarn
-      when File.exist?('pnpm-lock.yaml') then :pnpm
-      when File.exist?('package-lock.json') then :npm
-      when tool_exists?('bun') then :bun
-      when tool_exists?('yarn') then :yarn
-      when tool_exists?('pnpm') then :pnpm
-      when tool_exists?('npm') then :npm
-      end
-    end
+    private
 
-    def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
+    def using_tool?(tool)
+      system "command -v #{tool} > /dev/null" && LOCK_FILES[tool].any? { |file| File.exist?(file) }
     end
   end
 end

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -40,17 +40,17 @@ module Cssbundling
 
     def build_command
       case tool
-      when using_tool?(:bun) then "bun run build:css"
-      when using_tool?(:yarn) then "yarn build:css"
-      when using_tool?(:pnpm) then "pnpm build:css"
-      when using_tool?(:npm) then "npm run build:css"
+      when tool_exists?(:bun) then "bun run build:css"
+      when tool_exists?(:yarn) then "yarn build:css"
+      when tool_exists?(:pnpm) then "pnpm build:css"
+      when tool_exists?(:npm) then "npm run build:css"
       else raise "cssbundling-rails: No suitable tool found for building CSS"
       end
     end
 
     private
 
-    def using_tool?(tool)
+    def tool_exists?(tool)
       system "command -v #{tool} > /dev/null" && LOCK_FILES[tool].any? { |file| File.exist?(file) }
     end
   end

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -29,21 +29,21 @@ module Cssbundling
     }
 
     def install_command
-      case tool
-      when :bun then "bun install"
-      when :yarn then "yarn install"
-      when :pnpm then "pnpm install"
-      when :npm then "npm install"
+      case
+      when using_tool?(:bun) then "bun install"
+      when using_tool?(:yarn) then "yarn install"
+      when using_tool?(:pnpm) then "pnpm install"
+      when using_tool?(:npm) then "npm install"
       else raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
       end
     end
 
     def build_command
-      case tool
-      when tool_exists?(:bun) then "bun run build:css"
-      when tool_exists?(:yarn) then "yarn build:css"
-      when tool_exists?(:pnpm) then "pnpm build:css"
-      when tool_exists?(:npm) then "npm run build:css"
+      case
+      when using_tool?(:bun) then "bun run build:css"
+      when using_tool?(:yarn) then "yarn build:css"
+      when using_tool?(:pnpm) then "pnpm build:css"
+      when using_tool?(:npm) then "npm run build:css"
       else raise "cssbundling-rails: No suitable tool found for building CSS"
       end
     end
@@ -51,7 +51,11 @@ module Cssbundling
     private
 
     def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null" && LOCK_FILES[tool].any? { |file| File.exist?(file) }
+      system "command -v #{tool} > /dev/null"
+    end
+
+    def using_tool?(tool)
+      tool_exists?(tool) && LOCK_FILES[tool].any? { |file| File.exist?(file) }
     end
   end
 end


### PR DESCRIPTION
I'm using bun and install packages with `bun install --yarn` and its generate a yarn.lock file, same time new version of bun 1.2 generates `bun.lock` file instead of `bun.lockb`. 
Some users may have bun with `yarn.lock` file or bun with `bun.lock` 

My assets recompilation failed with:
```
RAILS_ENV=production rails assets:precompile
bin/rails aborted!
cssbundling-rails: Command install failed, ensure yarn is installed

Tasks: TOP => assets:precompile => css:build => css:install
(See full trace by running task with --trace)
```

Here is a proposal to handle this, idk what best way to do this. If this way looks ok I can fix test as well. Also we have `using_bun?` method at `Helpers` module that dose not check for `bun.lock` and return false if bun exists and yarn.lock present

- Add support for both old `bun.lockb` and new `bun.lock` Bun lock files
- Handle Bun with Yarn compatibility mode `yarn.lock`
- Combine command existence and lock file checks into single method