### PR TITLE
Fix install task typo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ PLATFORMS
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-24
   x86_64-darwin-20
   x86_64-darwin-21
   x86_64-linux

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -1,5 +1,5 @@
 namespace :css do
-  desc "Install JavaScript dependencies"
+  desc "Install CSS dependencies"
   task :install do
     command = Cssbundling::Tasks.install_command
     unless system(command)


### PR DESCRIPTION
Fix a tiny typo in the install task description.
