### PR TITLE
Pin tailwindcss to v3 to fix `rails new`

### DIFF
--- a/lib/install/tailwind/install.rb
+++ b/lib/install/tailwind/install.rb
@@ -6,7 +6,7 @@ apply "#{__dir__}/../install.rb"
 say "Install Tailwind (+PostCSS w/ autoprefixer)"
 copy_file "#{__dir__}/tailwind.config.js", "tailwind.config.js"
 copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.tailwind.css"
-run "#{bundler_cmd} add tailwindcss@latest postcss@latest autoprefixer@latest"
+run "#{bundler_cmd} add tailwindcss@3 postcss@latest autoprefixer@latest"
 
 say "Add build:css script"
 add_package_json_script "build:css",


### PR DESCRIPTION
Fixes rails/rails#54575

Many breaking changes were made in v4 that will require changes to `cssbundling-rails`' Tailwind installer.

This commit temporarily pins Tailwind to v3 to restore `rails new`' ability to generate new `cssbundling-rails` applications with Tailwind.