### PR TITLE
Added support for Windows

### DIFF
--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -51,7 +51,11 @@ module Cssbundling
     private
 
     def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
+      if Gem.win_platform?
+        system "where #{tool} 2>nul>nul"
+      else
+        system "command -v #{tool} > /dev/null"
+      end
     end
 
     def using_tool?(tool)


### PR DESCRIPTION
Currently cssbundling does not work on Windows:

>rake assets:precompile
The system cannot find the path specified.
The system cannot find the path specified.
The system cannot find the path specified.
The system cannot find the path specified.
rake aborted!
cssbundling-rails: No suitable tool found for installing JavaScript dependencies

Tasks: TOP => assets:precompile => css:build => css:install
(See full trace by running task with --trace)

The reason is checking for npm/yarn/etc with command -v which is Linux only way