### PR TITLE
fix: Unsafe shell command constructed from library input 

### DIFF
--- a/lib/install/helpers.rb
+++ b/lib/install/helpers.rb
@@ -19,7 +19,7 @@ module Helpers
   end
 
   def tool_exists?(tool)
-    system "command -v #{tool} > /dev/null"
+    system("command", "-v", tool, out: File::NULL, err: File::NULL)
   end
 
   def add_package_json_script(name, script, run_script=true)


### PR DESCRIPTION
Fix this problem, we should avoid passing interpolated strings to `system` that are constructed from potentially untrusted input. Instead, we should use the form of `system` that takes each argument separately, which bypasses the shell and avoids interpretation of special characters. In this case, we can replace `system "command -v #{tool} > /dev/null"` with `system("command", "-v", tool, out: File::NULL, err: File::NULL)`. This approach ensures that the `tool` argument is passed directly to the command without shell interpretation, and the output is redirected to `/dev/null` in a safe, cross-platform way. We only need to change the implementation of `tool_exists?` in `lib/install/helpers.rb`.
