### PR TITLE
Use application.css instead of application.tailwind.css for Tailwind …

### DIFF
--- a/lib/install/tailwind/install.rb
+++ b/lib/install/tailwind/install.rb
@@ -4,9 +4,9 @@ self.extend Helpers
 apply "#{__dir__}/../install.rb"
 
 say "Install Tailwind"
-copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.tailwind.css"
+copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.css"
 run "#{bundler_cmd} add tailwindcss@latest @tailwindcss/cli@latest"
 
 say "Add build:css script"
 add_package_json_script "build:css",
-  "#{bundler_x_cmd} @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
+  "#{bundler_x_cmd} @tailwindcss/cli -i ./app/assets/stylesheets/application.css -o ./app/assets/builds/application.css --minify"


### PR DESCRIPTION
Changes application.tailwind.css to application.css to resolve issues
with Rails 8's Propshaft asset pipeline when using stylesheet_link_tag :app.
Otherwise creates application.tailwind.css giving this issue:
https://github.com/rails/rails/issues/55791

The .tailwind.css extension was originally used to differentiate between
CSS frameworks, but now causes 404 errors in Rails 8 with Propshaft, which
includes all stylesheets files when using the :app symbol. This causes the
source file to be referenced alongside the compiled output.

Using application.css as the source filename aligns with modern Rails
conventions and prevents conflicts while maintaining backward compatibility
with Rails 7.