### PR TITLE
Detect package manager in install tasks

### DIFF
--- a/lib/cssbundling/package_manager.rb
+++ b/lib/cssbundling/package_manager.rb
@@ -1,0 +1,106 @@
+require "pathname"
+
+module Cssbundling
+  module PackageManager
+    extend self
+
+    MANAGERS = {
+      bun: {
+        add: "bun add %s",
+        add_dev: "bun add %s --dev",
+        install: "bun install",
+        build: "bun run build:css",
+        run: "bun run %s"
+      },
+      pnpm: {
+        add: "pnpm add %s",
+        add_dev: "pnpm add -D %s",
+        install: "pnpm install",
+        build: "pnpm run build:css",
+        run: "pnpm run %s"
+      },
+      npm: {
+        add: "npm install %s",
+        add_dev: "npm install -D %s",
+        install: "npm ci",
+        build: "npm run build:css",
+        run: "npm run %s"
+      },
+      yarn: {
+        add: "yarn add %s",
+        add_dev: "yarn add --dev %s",
+        install: "yarn install",
+        build: "yarn build:css",
+        run: "yarn %s"
+      }
+    }.freeze
+
+    def self.detect(root)
+      if root.join("bun.lock").exist? || root.join("bun.lockb").exist? || root.join("bun.config.js").exist?
+        :bun
+      elsif root.join("pnpm-lock.yaml").exist?
+        :pnpm
+      elsif root.join("package-lock.json").exist?
+        :npm
+      else
+        detect_by_executable || :yarn
+      end
+    end
+
+    def detect_by_executable
+      %i[ bun yarn pnpm npm ].each do |exe|
+        return exe if system "command -v #{exe} > /dev/null"
+      end
+
+      nil
+    end
+
+    def package_manager
+      @package_manager ||= PackageManager.detect(project_root)
+    end
+
+    def add_command(package, dev: false)
+      if dev
+        MANAGERS.dig(package_manager, :add_dev) % package
+      else
+        MANAGERS.dig(package_manager, :add) % package
+      end
+    end
+
+    def install_command
+      MANAGERS.dig(package_manager, :install)
+    end
+
+    def build_command(with_watch: false)
+      package_build_command = MANAGERS.dig(package_manager, :build)
+
+      if with_watch
+        if package_manager == :npm || package_manager == :pnpm
+          package_build_command += " -- --watch"
+        else
+          package_build_command += " --watch"
+        end
+      end
+
+      package_build_command
+    end
+
+    def run_command(task)
+      MANAGERS.dig(package_manager, :run) % task
+    end
+
+    def run_x_command
+      if package_manager == :bun
+        "bunx"
+      else
+        "npx"
+      end
+    end
+
+    private
+
+    def project_root
+      Pathname(!Rails.root.nil? ? Rails.root : Dir.pwd)
+    end
+  end
+end

--- a/lib/install/Procfile_for_node.dev
+++ b/lib/install/Procfile_for_node.dev
@@ -1,2 +1,2 @@
 web: env RUBY_DEBUG_OPEN=true bin/rails server
-css: yarn build:css --watch
+css: #{npm_build_watch}

--- a/lib/install/bootstrap/install.rb
+++ b/lib/install/bootstrap/install.rb
@@ -6,7 +6,7 @@ apply "#{__dir__}/../install.rb"
 say "Install Bootstrap with Bootstrap Icons, Popperjs/core and Autoprefixer"
 copy_file "#{__dir__}/application.bootstrap.scss",
    "app/assets/stylesheets/application.bootstrap.scss"
-run "#{bundler_cmd} add sass bootstrap bootstrap-icons @popperjs/core postcss postcss-cli autoprefixer nodemon"
+run Cssbundling::PackageManager.add_command("sass bootstrap bootstrap-icons @popperjs/core postcss postcss-cli autoprefixer nodemon")
 
 inject_into_file "config/initializers/assets.rb", after: /.*Rails.application.config.assets.paths.*\n/ do
   <<~RUBY
@@ -36,10 +36,10 @@ end
 
 add_package_json_script("build:css:compile", "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules")
 add_package_json_script("build:css:prefix", "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css")
-add_package_json_script("build:css", "#{bundler_run_cmd} build:css:compile && #{bundler_run_cmd} build:css:prefix")
-add_package_json_script("watch:css", "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \\\"#{bundler_run_cmd} build:css\\\"", false)
+add_package_json_script("build:css", "#{Cssbundling::PackageManager.run_command('build:css:compile')} && #{Cssbundling::PackageManager.run_command('build:css:prefix')}")
+add_package_json_script("watch:css", "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \\\"#{Cssbundling::PackageManager.build_command}\\\"", false)
 
-gsub_file "Procfile.dev", "build:css --watch", "watch:css"
+gsub_file "Procfile.dev", Cssbundling::PackageManager.build_command(with_watch: true), Cssbundling::PackageManager.run_command("watch:css")
 
 package_json = JSON.parse(File.read("package.json"))
 package_json["browserslist"] ||= {}

--- a/lib/install/bulma/install.rb
+++ b/lib/install/bulma/install.rb
@@ -6,7 +6,7 @@ apply "#{__dir__}/../install.rb"
 say "Install Bulma"
 copy_file "#{__dir__}/application.bulma.scss",
    "app/assets/stylesheets/application.bulma.scss"
-run "#{bundler_cmd} add sass bulma"
+run Cssbundling::PackageManager.add_command("sass bulma")
 
 say "Add build:css script"
 add_package_json_script "build:css",

--- a/lib/install/helpers.rb
+++ b/lib/install/helpers.rb
@@ -1,44 +1,24 @@
 require 'json'
+require "cssbundling/package_manager"
 
 module Helpers
-  def bundler_cmd
-    using_bun? ? "bun" : "yarn"
-  end
-
-  def bundler_run_cmd
-    using_bun? ? "bun run" : "yarn"
-  end
-
-  def bundler_x_cmd
-    using_bun? ? "bunx" : "npx"
-  end
-
-  def using_bun?
-    tool_exists?('bun') && (File.exist?('bun.lockb') || 
-                            File.exist?('bun.lock'))
-  end
-
-  def tool_exists?(tool)
-    system "command -v #{tool} > /dev/null"
-  end
-
   def add_package_json_script(name, script, run_script=true)
-    if using_bun?
+    if Cssbundling::PackageManager.package_manager == :bun
       package_json = JSON.parse(File.read("package.json"))
       package_json["scripts"] ||= {}
       package_json["scripts"][name] = script.gsub('\\"', '"')
       File.write("package.json", JSON.pretty_generate(package_json))
-      run %(bun run #{name}) if run_script
+      run Cssbundling::PackageManager.run_command(name) if run_script
     else
       case `npx -v`.to_f
       when 7.1...8.0
         say "Add #{name} script"
         run %(npm set-script #{name} "#{script}")
-        run %(yarn #{name}) if run_script
+        run Cssbundling::PackageManager.run_command(name) if run_script
       when (8.0..)
         say "Add #{name} script"
         run %(npm pkg set scripts.#{name}="#{script}")
-        run %(yarn #{name}) if run_script
+        run Cssbundling::PackageManager.run_command(name) if run_script
       else
         say %(Add "scripts": { "#{name}": "#{script}" } to your package.json), :green
       end

--- a/lib/install/install.rb
+++ b/lib/install/install.rb
@@ -1,5 +1,4 @@
-require_relative "helpers"
-self.extend Helpers
+require "cssbundling/package_manager"
 
 say "Build into app/assets/builds"
 empty_directory "app/assets/builds"
@@ -46,10 +45,11 @@ unless Rails.root.join("package.json").exist?
 end
 
 if Rails.root.join("Procfile.dev").exist?
-  append_to_file "Procfile.dev", "css: #{bundler_run_cmd} build:css --watch\n"
+  append_to_file "Procfile.dev", "css: #{Cssbundling::PackageManager.build_command(with_watch:true)}\n"
 else
   say "Add default Procfile.dev"
   copy_file "#{__dir__}/#{using_bun? ? "Procfile_for_bun.dev" : "Procfile_for_node.dev"}", "Procfile.dev"
+  gsub_file "Procfile.dev", 'css: #{npm_build_watch}', "css: #{Cssbundling::PackageManager.build_command(with_watch:true)}"
 
   say "Ensure foreman is installed"
   run "gem install foreman"

--- a/lib/install/postcss/install.rb
+++ b/lib/install/postcss/install.rb
@@ -6,7 +6,7 @@ apply "#{__dir__}/../install.rb"
 say "Install PostCSS w/ nesting and autoprefixer"
 copy_file "#{__dir__}/postcss.config.js", "postcss.config.js"
 copy_file "#{__dir__}/application.postcss.css", "app/assets/stylesheets/application.postcss.css"
-run "#{bundler_cmd} add postcss postcss-cli postcss-import postcss-nesting autoprefixer"
+run Cssbundling::PackageManager.add_command("postcss postcss-cli postcss-import postcss-nesting autoprefixer")
 
 say "Add build:css script"
 add_package_json_script "build:css",

--- a/lib/install/sass/install.rb
+++ b/lib/install/sass/install.rb
@@ -5,7 +5,7 @@ apply "#{__dir__}/../install.rb"
 
 say "Install Sass"
 copy_file "#{__dir__}/application.sass.scss", "app/assets/stylesheets/application.sass.scss"
-run "#{bundler_cmd} add sass"
+run Cssbundling::PackageManager.add_command("sass")
 
 say "Add build:css script"
 add_package_json_script "build:css",

--- a/lib/install/tailwind/install.rb
+++ b/lib/install/tailwind/install.rb
@@ -5,8 +5,9 @@ apply "#{__dir__}/../install.rb"
 
 say "Install Tailwind"
 copy_file "#{__dir__}/application.tailwind.css", "app/assets/stylesheets/application.tailwind.css"
-run "#{bundler_cmd} add tailwindcss@latest @tailwindcss/cli@latest"
+run Cssbundling::PackageManager.add_command("tailwindcss@latest @tailwindcss/cli@latest")
+
 
 say "Add build:css script"
 add_package_json_script "build:css",
-  "#{bundler_x_cmd} @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"
+  "#{Cssbundling::PackageManager.run_x_command} @tailwindcss/cli -i ./app/assets/stylesheets/application.tailwind.css -o ./app/assets/builds/application.css --minify"

--- a/lib/tasks/cssbundling/build.rake
+++ b/lib/tasks/cssbundling/build.rake
@@ -1,63 +1,20 @@
+require "cssbundling/package_manager"
+
 namespace :css do
   desc "Install CSS dependencies"
   task :install do
-    command = Cssbundling::Tasks.install_command
-    unless system(command)
-      raise "cssbundling-rails: Command install failed, ensure #{command.split.first} is installed"
+    unless system(Cssbundling::PackageManager.install_command)
+      raise "cssbundling-rails: Command install failed, ensure #{Cssbundling::PackageManager.package_manager} is installed"
     end
   end
 
   desc "Build your CSS bundle"
   build_task = task :build do
-    command = Cssbundling::Tasks.build_command
-    unless system(command)
-      raise "cssbundling-rails: Command build failed, ensure `#{command}` runs without errors"
+    unless system(Cssbundling::PackageManager.build_command)
+      raise "cssbundling-rails: Command build failed, ensure `#{Cssbundling::PackageManager.build_command}` runs without errors"
     end
   end
   build_task.prereqs << :install unless ENV["SKIP_YARN_INSTALL"] || ENV["SKIP_BUN_INSTALL"]
-end
-
-module Cssbundling
-  module Tasks
-    extend self
-
-    LOCK_FILES = {
-      bun: %w[bun.lockb bun.lock],
-      yarn: %w[yarn.lock],
-      pnpm: %w[pnpm-lock.yaml],
-      npm: %w[package-lock.json]
-    }
-
-    def install_command
-      case
-      when using_tool?(:bun) then "bun install"
-      when using_tool?(:yarn) then "yarn install"
-      when using_tool?(:pnpm) then "pnpm install"
-      when using_tool?(:npm) then "npm install"
-      else raise "cssbundling-rails: No suitable tool found for installing JavaScript dependencies"
-      end
-    end
-
-    def build_command
-      case
-      when using_tool?(:bun) then "bun run build:css"
-      when using_tool?(:yarn) then "yarn build:css"
-      when using_tool?(:pnpm) then "pnpm build:css"
-      when using_tool?(:npm) then "npm run build:css"
-      else raise "cssbundling-rails: No suitable tool found for building CSS"
-      end
-    end
-
-    private
-
-    def tool_exists?(tool)
-      system "command -v #{tool} > /dev/null"
-    end
-
-    def using_tool?(tool)
-      tool_exists?(tool) && LOCK_FILES[tool].any? { |file| File.exist?(file) }
-    end
-  end
 end
 
 unless ENV["SKIP_CSS_BUILD"]


### PR DESCRIPTION
### Motivation / Background

When running `./bin/rails css:install:[tailwind|bootstrap|bulma|postcss|sass]`,
the generated setup hardcodes `yarn` commands instead of using the detected package manager.

- https://github.com/rails/cssbundling-rails/blob/42c3e7d20198ca3a3d81dd6db44e0ab4cd1ab261/lib/install/helpers.rb#L5
- https://github.com/rails/cssbundling-rails/blob/42c3e7d20198ca3a3d81dd6db44e0ab4cd1ab261/lib/install/Procfile_for_node.dev#L2

This is inconsistent with the dynamic package manager detection already present in the build/install rake tasks.
This PR aligns the install task behavior with the approach taken in `rails/rails` and `rails/jsbundling-rails`:

- https://github.com/rails/rails/pull/56636
- https://github.com/rails/jsbundling-rails/pull/224

### Detail

This PR introduces `Cssbundling::PackageManager`, following the same approach used in
`rails/rails` (`Rails::Generators::JsPackageManager`) and `rails/jsbundling-rails` (`Jsbundling::PackageManager`).

`Cssbundling::PackageManager` replaces the existing `Cssbundling::Install::Helpers` implementation:
https://github.com/rails/cssbundling-rails/blob/42c3e7d20198ca3a3d81dd6db44e0ab4cd1ab261/lib/install/helpers.rb#L3

**Before:** `css:install:*` tasks hardcode `yarn` (or `bun`) in generated files regardless of the project's actual package manager.
**After:** The detected package manager (yarn / npm / pnpm / bun) is used consistently across both build tasks and install tasks.

### Additional Information
#### Default package manager

If no lockfile (e.g. `bun.lockb`, `yarn.lock`, `pnpm-lock.yaml`, `package-lock.json`) is found, Yarn is used as the default for backward compatibility with existing projects.
This is aligned with the current released Rails version (v8.1.3).